### PR TITLE
Implement scrolling BasicUIView grids to the bottom plus refactoring

### DIFF
--- a/ObservatoryCore/UI/ViewModels/BasicUIViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/BasicUIViewModel.cs
@@ -29,8 +29,6 @@ namespace Observatory.UI.ViewModels
 
         public BasicUIViewModel(ObservableCollection<object> BasicUIGrid)
         {
-         
-            this.BasicUIGrid = new();
             this.BasicUIGrid = BasicUIGrid;
         }
 

--- a/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
@@ -30,12 +30,10 @@ namespace Observatory.UI.ViewModels
                 {
                     CoreModel coreModel = new();
                     coreModel.Name = worker.ShortName;
-                    coreModel.UI = new();
-                    var uiViewModel = new BasicUIViewModel(worker.PluginUI.DataGrid)
+                    coreModel.UI = new BasicUIViewModel(worker.PluginUI.DataGrid)
                     {
                         UIType = worker.PluginUI.PluginUIType
                     };
-                    coreModel.UI = uiViewModel;
                     
                     tabs.Add(coreModel);
                 }


### PR DESCRIPTION
Upon arrival of new records to the backing ObservableCollection, scroll the DataGrid to the last item. However, when the DataGrid is initialized, there's not yet a data context set, so when that happens, then we can listen to the CollectionChanged event to trigger scrolling (only really needed for additions).

In passing, also set the DataGrid to ReadOnly.

In the other two files, minor simplifications/cleanup.