### PR TITLE
Implement "Pre-reading" of current system context when starting monitor

### DIFF
--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -42,6 +42,12 @@ namespace Observatory
 
         public void Start()
         {
+            if (firstStarMonitor)
+            {
+                // Only pre-read on first start monitor. Beyond that it's simply pause/resume.
+                firstStarMonitor = false;
+                PrereadJournals();
+            }
             journalWatcher.EnableRaisingEvents = true;
             statusWatcher.EnableRaisingEvents = true;
             monitoring = true;
@@ -79,68 +85,67 @@ namespace Observatory
 
         public void ReadAllJournals(string path)
         {
+            // Prevent pre-reading when starting monitoring after reading all.
+            firstStarMonitor = false;
             readall = true;
             DirectoryInfo logDirectory = GetJournalFolder(path);
             var files = logDirectory.GetFiles("Journal.????????????.??.log");
             var readErrors = new List<(Exception ex, string file, string line)>();
             foreach (var file in files)
             {
+                readErrors.AddRange(
+                    ProcessLines(ReadAllLines(file.FullName), file.Name));
+            }
+
+            ReportErrors(readErrors);
+            readall = false;
+        }
+
+        public void PrereadJournals()
+        {
+            // TODO: use the configured journal path, not the "default" detected path.
+            DirectoryInfo logDirectory = GetJournalFolder(String.Empty);
+            var files = logDirectory.GetFiles("Journal.????????????.??.log");
+
+            // Read at most the last two files (in case we were launched after the game and the latest
+            // journal is mostly empty) but keeping only the lines since the last FSDJump.
+            List<String> lastSystemLines = new();
+            string lastLoadGame = String.Empty;
+            bool sawFSDJump = false;
+            foreach (var file in files.Skip(Math.Max(files.Length - 2, 0)))
+            {
                 var lines = ReadAllLines(file.FullName);
                 foreach (var line in lines)
                 {
-                    try
+                    var eventType = JournalUtilities.GetEventType(line);
+                    if (eventType.Equals("FSDJump"))
                     {
-                        DeserializeAndInvoke(line);
+                        // Reset, start collecting again.
+                        lastSystemLines.Clear();
+                        sawFSDJump = true;
                     }
-                    catch (Exception ex)
+                    else if (eventType.Equals("LoadGame"))
                     {
-                        readErrors.Add((ex, file.Name, line));
+                        lastLoadGame = line;
                     }
+                    lastSystemLines.Add(line);
                 }
             }
 
-            if (readErrors.Any())
+            // So we didn't see a jump in the recent logs. We could be re-logging, or something.
+            // Just bail on this attempt.
+            if (!sawFSDJump) return;
+
+            // If we saw a LoadGame, insert it as well. This ensures odyssey biologicials are properly
+            // counted/presented.
+            if (!String.IsNullOrEmpty(lastLoadGame))
             {
-                var errorContent = new System.Text.StringBuilder();
-                int count = 0;
-                foreach (var error in readErrors)
-                {
-                    errorContent.AppendLine(error.ex.InnerException.Message);
-                    errorContent.AppendLine($"File: {error.file}");
-                    if (error.line.Length > 200)
-                    {
-                        errorContent.AppendLine($"Line (first 200 chars): {error.line.Substring(0,200)}");
-                    }
-                    else
-                    {
-                        errorContent.AppendLine($"Line: {error.line}");
-                    }
-                    
-                    if (error != readErrors.Last())
-                    {
-                        errorContent.AppendLine();
-                        if (count++ == 5)
-                        {
-                            errorContent.AppendLine($"There are {readErrors.Count - 6} more errors but let's keep this window manageable.");
-                            break;
-                        }
-                    }
-                }
-                
-                if (Avalonia.Application.Current.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
-                {
-                    var errorMessage = MessageBox.Avalonia.MessageBoxManager
-                    .GetMessageBoxStandardWindow(new MessageBox.Avalonia.DTO.MessageBoxStandardParams
-                    {
-                        ContentTitle = $"Journal Read Error{(readErrors.Count > 1 ? "s" : "")}",
-                        ContentMessage = errorContent.ToString()
-                    });
-                    errorMessage.ShowDialog(desktop.MainWindow);
-
-                }
-                
+                lastSystemLines.Insert(0, lastLoadGame);
             }
-            readall = false;
+
+            // We found an FSD jump, buffered the lines for that system (possibly including startup logs
+            // over a file boundary). Pump these through the plugins.
+            ReportErrors(ProcessLines(lastSystemLines, "Pre-read"));
         }
 
         #endregion
@@ -161,6 +166,7 @@ namespace Observatory
         private Dictionary<string, int> currentLine;
         private bool monitoring = false;
         private bool readall = false;
+        private bool firstStarMonitor = true;
 
         #endregion
 
@@ -226,6 +232,23 @@ namespace Observatory
             return logDirectory;
         }
 
+        private List<(Exception ex, string file, string line)> ProcessLines(List<String> lines, string file)
+        {
+            var readErrors = new List<(Exception ex, string file, string line)>();
+            foreach (var line in lines)
+            {
+                try
+                {
+                    DeserializeAndInvoke(line);
+                }
+                catch (Exception ex)
+                {
+                    readErrors.Add((ex, "Pre-read", line));
+                }
+            }
+            return readErrors;
+        }
+
         private void DeserializeAndInvoke(string line)
         {
             var eventType = JournalUtilities.GetEventType(line);
@@ -243,6 +266,51 @@ namespace Observatory
 
             handler?.Invoke(this, journalEvent);
 
+        }
+
+        private void ReportErrors(List<(Exception ex, string file, string line)> readErrors)
+        {
+            if (readErrors.Any())
+            {
+                var errorContent = new System.Text.StringBuilder();
+                int count = 0;
+                foreach (var error in readErrors)
+                {
+                    errorContent.AppendLine(error.ex.InnerException.Message);
+                    errorContent.AppendLine($"File: {error.file}");
+                    if (error.line.Length > 200)
+                    {
+                        errorContent.AppendLine($"Line (first 200 chars): {error.line.Substring(0, 200)}");
+                    }
+                    else
+                    {
+                        errorContent.AppendLine($"Line: {error.line}");
+                    }
+
+                    if (error != readErrors.Last())
+                    {
+                        errorContent.AppendLine();
+                        if (count++ == 5)
+                        {
+                            errorContent.AppendLine($"There are {readErrors.Count - 6} more errors but let's keep this window manageable.");
+                            break;
+                        }
+                    }
+                }
+
+                if (Avalonia.Application.Current.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+                {
+                    var errorMessage = MessageBox.Avalonia.MessageBoxManager
+                    .GetMessageBoxStandardWindow(new MessageBox.Avalonia.DTO.MessageBoxStandardParams
+                    {
+                        ContentTitle = $"Journal Read Error{(readErrors.Count > 1 ? "s" : "")}",
+                        ContentMessage = errorContent.ToString()
+                    });
+                    errorMessage.ShowDialog(desktop.MainWindow);
+
+                }
+
+            }
         }
 
         private void LogChangedEvent(object source, FileSystemEventArgs eventArgs)

--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -42,10 +42,10 @@ namespace Observatory
 
         public void Start()
         {
-            if (firstStarMonitor)
+            if (firstStartMonitor)
             {
                 // Only pre-read on first start monitor. Beyond that it's simply pause/resume.
-                firstStarMonitor = false;
+                firstStartMonitor = false;
                 PrereadJournals();
             }
             journalWatcher.EnableRaisingEvents = true;
@@ -86,7 +86,7 @@ namespace Observatory
         public void ReadAllJournals(string path)
         {
             // Prevent pre-reading when starting monitoring after reading all.
-            firstStarMonitor = false;
+            firstStartMonitor = false;
             readall = true;
             DirectoryInfo logDirectory = GetJournalFolder(path);
             var files = logDirectory.GetFiles("Journal.????????????.??.log");
@@ -167,7 +167,7 @@ namespace Observatory
         private Dictionary<string, int> currentLine;
         private bool monitoring = false;
         private bool readall = false;
-        private bool firstStarMonitor = true;
+        private bool firstStartMonitor = true;
 
         #endregion
 

--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -103,8 +103,9 @@ namespace Observatory
 
         public void PrereadJournals()
         {
-            // TODO: use the configured journal path, not the "default" detected path.
-            DirectoryInfo logDirectory = GetJournalFolder(String.Empty);
+            if (!Properties.Core.Default.TryPrimeSystemContextOnStartMonitor) return;
+
+            DirectoryInfo logDirectory = GetJournalFolder(Properties.Core.Default.JournalFolder);
             var files = logDirectory.GetFiles("Journal.????????????.??.log");
 
             // Read at most the last two files (in case we were launched after the game and the latest

--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -58,5 +58,20 @@ namespace Observatory.Properties {
                 this["NativeNotify"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool TryPrimeSystemContextOnStartMonitor
+        {
+            get
+            {
+                return ((bool)(this["TryPrimeSystemContextOnStartMonitor"]));
+            }
+            set
+            {
+                this["TryPrimeSystemContextOnStartMonitor"] = value;
+            }
+        }
     }
 }

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -138,13 +138,18 @@ namespace Observatory.UI.Views
             {
                 new RowDefinition() { Height = new GridLength(0, GridUnitType.Auto) },
                 new RowDefinition() { Height = new GridLength(0, GridUnitType.Auto) },
+                new RowDefinition() { Height = new GridLength(0, GridUnitType.Auto) },
                 new RowDefinition() { Height = new GridLength(0, GridUnitType.Auto) }
             };
             corePanel.RowDefinitions = rows;
 
+            SettingRowTracker rowTracker = new SettingRowTracker(corePanel);
+
             #region Native Settings
 
-            TextBlock nativeNotifyLabel = new() { Text = "Basic Notification" }; ;
+            #region Notification settings
+
+            TextBlock nativeNotifyLabel = new() { Text = "Basic Notification" };
             CheckBox nativeNotifyCheckbox = new() { IsChecked = Properties.Core.Default.NativeNotify, Content = nativeNotifyLabel };
 
             nativeNotifyCheckbox.Checked += (object sender, RoutedEventArgs e) =>
@@ -159,8 +164,30 @@ namespace Observatory.UI.Views
                 Properties.Core.Default.Save();
             };
 
-            corePanel.AddControl(nativeNotifyCheckbox, 1, 0, 2);
-            
+            corePanel.AddControl(nativeNotifyCheckbox, rowTracker.NextIndex(), 0, 2);
+
+            #endregion
+
+            #region System Context Priming setting
+
+            TextBlock primeSystemContextLabel = new() { Text = "Try re-load current system information when starting monitor" };
+            CheckBox primeSystemContexCheckbox = new() { IsChecked = Properties.Core.Default.TryPrimeSystemContextOnStartMonitor, Content = primeSystemContextLabel };
+
+            primeSystemContexCheckbox.Checked += (object sender, RoutedEventArgs e) =>
+            {
+                Properties.Core.Default.TryPrimeSystemContextOnStartMonitor = true;
+                Properties.Core.Default.Save();
+            };
+
+            primeSystemContexCheckbox.Unchecked += (object sender, RoutedEventArgs e) =>
+            {
+                Properties.Core.Default.TryPrimeSystemContextOnStartMonitor = false;
+                Properties.Core.Default.Save();
+            };
+
+            corePanel.AddControl(primeSystemContexCheckbox, rowTracker.NextIndex(), 0, 2);
+
+            #endregion
 
             #endregion
 
@@ -207,9 +234,10 @@ namespace Observatory.UI.Views
                 
             };
 
-            corePanel.AddControl(journalPathLabel, 2, 0);
-            corePanel.AddControl(journalPath, 2, 1);
-            corePanel.AddControl(journalBrowse, 2, 2);
+            int journalPathRowIndex = rowTracker.NextIndex();
+            corePanel.AddControl(journalPathLabel, journalPathRowIndex, 0);
+            corePanel.AddControl(journalPath, journalPathRowIndex, 1);
+            corePanel.AddControl(journalBrowse, journalPathRowIndex, 2);
 
             #endregion
 
@@ -249,7 +277,7 @@ namespace Observatory.UI.Views
             }
 
             pluginList.Items = allPlugins;
-            corePanel.AddControl(pluginList, 0, 0, 2);
+            corePanel.AddControl(pluginList, SettingRowTracker.PLUGIN_LIST_ROW_INDEX, 0, 2);
 
             #endregion
 
@@ -450,5 +478,34 @@ namespace Observatory.UI.Views
             Grid.SetColumn(control, column);
             Grid.SetRow(control, row);
         }
+    }
+
+    internal class SettingRowTracker
+    {
+        public const int PLUGIN_LIST_ROW_INDEX = 0;
+        private int nextSettingRowIndex;
+
+        private Grid settingPanel;
+
+        public SettingRowTracker(Grid settingPanel)
+        {
+            this.settingPanel = settingPanel;
+            Reset();
+        }
+
+        public int NextIndex()
+        {
+            if (nextSettingRowIndex > settingPanel.RowDefinitions.Count)
+            {
+                throw new IndexOutOfRangeException("Trying to add more settings than rows in the settings grid.");
+            }
+            return nextSettingRowIndex++;
+        }
+
+        private void Reset()
+        {
+            nextSettingRowIndex = PLUGIN_LIST_ROW_INDEX + 1;
+        }
+
     }
 }


### PR DESCRIPTION
The first time you click "Start monitor" (assuming you haven't read-all), we read the last 2 log files to find the journal entries for the last system jumped into (if we can find the FSDJump entry) in order to re-populate the information in all interested plugins. Its much faster than reading all to restore current system context.

- For Botanist plugin, this will display what plants/planets you've already sampled and avoids placeholder planet entries with incorrect bio counts.
- For Explorer, it re-lists interesting items, in case you weren't done exploring the system.

A baby step for Xjph/ObservatoryCore#5