### PR TITLE
Enclose pre-read with Read-all; de-dupe plugin table and show types, etc

### DIFF
--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -146,7 +146,9 @@ namespace Observatory
 
             // We found an FSD jump, buffered the lines for that system (possibly including startup logs
             // over a file boundary). Pump these through the plugins.
+            readall = true;
             ReportErrors(ProcessLines(lastSystemLines, "Pre-read"));
+            readall = false;
         }
 
         #endregion

--- a/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
@@ -55,21 +55,15 @@ namespace Observatory.UI.ViewModels
 
         public void ReadAll()
         {
-            foreach (var worker in workers)
-            {
-                worker.ReadAllStarted();
-            }
+            SetWorkerReadAllState(true);
             LogMonitor.GetInstance.ReadAllJournals();
-            foreach (var worker in workers)
-            {
-                worker.ReadAllFinished();
-            }
+            SetWorkerReadAllState(false);
         }
 
         public void ToggleMonitor()
         {
             var logMonitor = LogMonitor.GetInstance;
-            
+
             if (logMonitor.IsMonitoring())
             {
                 logMonitor.Stop();
@@ -77,7 +71,10 @@ namespace Observatory.UI.ViewModels
             }
             else
             {
+                // HACK: Find a better way of suppressing notifications when pre-reading.
+                SetWorkerReadAllState(true);
                 logMonitor.Start();
+                SetWorkerReadAllState(false);
                 ToggleButtonText = "Stop Monitor";
             }
         }
@@ -123,5 +120,20 @@ namespace Observatory.UI.ViewModels
         {
             get { return tabs; }
         }
+        private void SetWorkerReadAllState(bool isReadingAll)
+        {
+            foreach (var worker in workers)
+            {
+                if (isReadingAll)
+                {
+                    worker.ReadAllStarted();
+                }
+                else
+                {
+                    worker.ReadAllFinished();
+                }
+            }
+        }
+
     }
 }

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -452,11 +452,6 @@ namespace Observatory.UI.Views
             }
         }
 
-        private void TextBox_TextInput(object sender, Avalonia.Input.TextInputEventArgs e)
-        {
-            throw new NotImplementedException();
-        }
-
         private string GetStatusText(PluginManagement.PluginManager.PluginStatus status)
         {
             string statusText;


### PR DESCRIPTION
A number changes in preparation for the upcoming Announcer plugin.
1) De-dupe entries in the plugin table in the core settings UI when a plugin implements both Worker and Notifier interfaces.
2) Also add a "Types" column to the plugin table indicating the set of implemented interfaces found.
3) Wrap the pre-reading logic in "Read-all" scope to properly suppress  a stampede of notifications (particularly audio ones) when starting the log monitor.
4) Fix the int setting UI. It rendered incorrectly, it didn't get the value from the settings class, nor wrote it back. Also implemented optional value bounding using the new setting attribute (see the related Framework PR). 
5) Applied similar fixes to string setting (addressed rendering, write-back although untested).
6) Minor visual fixes (height/vertical alignment) for non-boolean settings to address cut-off/overlapping inputs.

Sorry for the larger PR, but these *should* be all the loose ends before we could consider including Basic Announcer...

The screencap below shows the current state of core settings UI.

![image](https://user-images.githubusercontent.com/54195004/129433764-9abd107b-453e-4bf1-a001-b928e3da416a.png)