### PR TITLE
Make Pre-read act similarly to "Read All"

### DIFF
--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -146,7 +146,9 @@ namespace Observatory
 
             // We found an FSD jump, buffered the lines for that system (possibly including startup logs
             // over a file boundary). Pump these through the plugins.
+            readall = true;
             ReportErrors(ProcessLines(lastSystemLines, "Pre-read"));
+            readall = false;
         }
 
         #endregion

--- a/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
@@ -55,21 +55,15 @@ namespace Observatory.UI.ViewModels
 
         public void ReadAll()
         {
-            foreach (var worker in workers)
-            {
-                worker.ReadAllStarted();
-            }
+            SetWorkerReadAllState(true);
             LogMonitor.GetInstance.ReadAllJournals();
-            foreach (var worker in workers)
-            {
-                worker.ReadAllFinished();
-            }
+            SetWorkerReadAllState(false);
         }
 
         public void ToggleMonitor()
         {
             var logMonitor = LogMonitor.GetInstance;
-            
+
             if (logMonitor.IsMonitoring())
             {
                 logMonitor.Stop();
@@ -77,7 +71,10 @@ namespace Observatory.UI.ViewModels
             }
             else
             {
+                // HACK: Find a better way of suppressing notifications when pre-reading.
+                SetWorkerReadAllState(true);
                 logMonitor.Start();
+                SetWorkerReadAllState(false);
                 ToggleButtonText = "Stop Monitor";
             }
         }
@@ -123,5 +120,21 @@ namespace Observatory.UI.ViewModels
         {
             get { return tabs; }
         }
+
+        private void SetWorkerReadAllState(bool isReadingAll)
+        {
+            foreach (var worker in workers)
+            {
+                if (isReadingAll)
+                {
+                    worker.ReadAllStarted();
+                }
+                else
+                {
+                    worker.ReadAllFinished();
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This has the effect of suppressing notifications when restoring current system context after initial click on "Start Monitor".

Split out from https://github.com/Xjph/ObservatoryCore/pull/10.