### PR TITLE
feat: cosmetic overhaul of native notification popup

### DIFF
--- a/ObservatoryCore/ObservatoryCore.cs
+++ b/ObservatoryCore/ObservatoryCore.cs
@@ -9,6 +9,13 @@ namespace Observatory
         [STAThread]
         static void Main(string[] args)
         {
+            string version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
+            if (Properties.Core.Default.CoreVersion != version)
+            {
+                Properties.Core.Default.Upgrade();
+                Properties.Core.Default.CoreVersion = version;
+                Properties.Core.Default.Save();
+            }
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
 

--- a/ObservatoryCore/ObservatoryCore.csproj
+++ b/ObservatoryCore/ObservatoryCore.csproj
@@ -27,7 +27,8 @@
     <PackageReference Include="Avalonia.Desktop" Version="0.10.6" />
     <PackageReference Include="Avalonia.Diagnostics" Version="0.10.6" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.6" />
-    <PackageReference Include="MessageBox.Avalonia" Version="1.3.1" />
+    <PackageReference Include="Egorozh.ColorPicker.Avalonia.Dialog" Version="0.10.1" />
+    <PackageReference Include="MessageBox.Avalonia" Version="1.5.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
   </ItemGroup>
 

--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -97,7 +97,7 @@ namespace Observatory.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        [global::System.Configuration.DefaultSettingValueAttribute("-1")]
         public int NativeNotifyScreen {
             get {
                 return ((int)(this["NativeNotifyScreen"]));

--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -58,19 +58,76 @@ namespace Observatory.Properties {
                 this["NativeNotify"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool TryPrimeSystemContextOnStartMonitor
-        {
-            get
-            {
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string NativeNotifyFont {
+            get {
+                return ((string)(this["NativeNotifyFont"]));
+            }
+            set {
+                this["NativeNotifyFont"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("4294944000")]
+        public uint NativeNotifyColour {
+            get {
+                return ((uint)(this["NativeNotifyColour"]));
+            }
+            set {
+                this["NativeNotifyColour"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int NativeNotifyCorner {
+            get {
+                return ((int)(this["NativeNotifyCorner"]));
+            }
+            set {
+                this["NativeNotifyCorner"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int NativeNotifyScreen {
+            get {
+                return ((int)(this["NativeNotifyScreen"]));
+            }
+            set {
+                this["NativeNotifyScreen"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool TryPrimeSystemContextOnStartMonitor {
+            get {
                 return ((bool)(this["TryPrimeSystemContextOnStartMonitor"]));
             }
-            set
-            {
+            set {
                 this["TryPrimeSystemContextOnStartMonitor"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string CoreVersion {
+            get {
+                return ((string)(this["CoreVersion"]));
+            }
+            set {
+                this["CoreVersion"] = value;
             }
         }
     }

--- a/ObservatoryCore/Properties/Core.settings
+++ b/ObservatoryCore/Properties/Core.settings
@@ -21,7 +21,7 @@
       <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="NativeNotifyScreen" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">0</Value>
+      <Value Profile="(Default)">-1</Value>
     </Setting>
     <Setting Name="TryPrimeSystemContextOnStartMonitor" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>

--- a/ObservatoryCore/Properties/Core.settings
+++ b/ObservatoryCore/Properties/Core.settings
@@ -11,5 +11,23 @@
     <Setting Name="NativeNotify" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="NativeNotifyFont" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="NativeNotifyColour" Type="System.UInt32" Scope="User">
+      <Value Profile="(Default)">4294944000</Value>
+    </Setting>
+    <Setting Name="NativeNotifyCorner" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="NativeNotifyScreen" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="TryPrimeSystemContextOnStartMonitor" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="CoreVersion" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ObservatoryCore/UI/MainApplication.axaml
+++ b/ObservatoryCore/UI/MainApplication.axaml
@@ -1,5 +1,6 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:dialog="clr-namespace:Egorozh.ColorPicker.Dialog;assembly=Egorozh.ColorPicker.Avalonia.Dialog"
              xmlns:local="clr-namespace:Observatory.UI"
              x:Class="Observatory.UI.MainApplication">
   <Application.DataTemplates>
@@ -9,5 +10,7 @@
     <FluentTheme Mode="Dark"/>
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Default.xaml"/>
     <StyleInclude Source="resm:Avalonia.Themes.Default.Accents.BaseDark.xaml?assembly=Avalonia.Themes.Default"/>
+    <StyleInclude Source="avares://Egorozh.ColorPicker.Avalonia.Dialog/Themes/Default.axaml" />
+    <dialog:FluentColorPickerTheme Mode="Dark" />
   </Application.Styles>
 </Application>

--- a/ObservatoryCore/UI/Models/NotificationModel.cs
+++ b/ObservatoryCore/UI/Models/NotificationModel.cs
@@ -10,5 +10,6 @@ namespace Observatory.UI.Models
     {
         public string Title { get; set; }
         public string Detail { get; set; }
+        public string Colour { get; set; }
     }
 }

--- a/ObservatoryCore/UI/ViewModels/NotificationViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/NotificationViewModel.cs
@@ -10,7 +10,13 @@ namespace Observatory.UI.ViewModels
     {
         public NotificationViewModel(string title, string detail)
         {
-            Notification = new() { Title = title, Detail = detail };
+
+            Notification = new()
+            {
+                Title = title,
+                Detail = detail,
+                Colour = Avalonia.Media.Color.FromUInt32(Properties.Core.Default.NativeNotifyColour).ToString()
+            };
             
         }
 

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -194,7 +194,24 @@ namespace Observatory.UI.Views
                 Properties.Core.Default.Save();
             };
             
-            notificationGrid.AddControl(nativeNotifyCheckbox, 4, 0, 3);
+            notificationGrid.AddControl(nativeNotifyCheckbox, 4, 0);
+
+            Button notifyTestButton = new()
+            { 
+                Content = "Test",
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right
+            };
+
+            notifyTestButton.Click += (object sender, RoutedEventArgs e) =>
+            {
+                Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    var notifyWindow = new UI.Views.NotificationView() { DataContext = new UI.ViewModels.NotificationViewModel("Debug Notification", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras suscipit hendrerit libero ac scelerisque.") };
+                    notifyWindow.Show();
+                });
+            };
+
+            notificationGrid.AddControl(notifyTestButton, 4, 1);
 
             TextBlock notifyFontLabel = new() 
             { 
@@ -338,15 +355,6 @@ namespace Observatory.UI.Views
             
 
             corePanel.AddControl(notificationExpander, rowTracker.NextIndex(), 0, 2);
-
-
-#if DEBUG
-            Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                var notifyWindow = new UI.Views.NotificationView() { DataContext = new UI.ViewModels.NotificationViewModel("Debug Notification", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras suscipit hendrerit libero ac scelerisque.") };
-                notifyWindow.Show();
-            });
-#endif
 
 #endregion
 

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using Avalonia.Media;
+using Avalonia.Controls.ApplicationLifetimes;
 
 namespace Observatory.UI.Views
 {
@@ -247,7 +248,10 @@ namespace Observatory.UI.Views
 
             List<string> displays = new();
             displays.Add("Primary");
-            var screens = ((Window)Parent.Parent.Parent.Parent).Screens.All;
+
+            var application = (IClassicDesktopStyleApplicationLifetime)Application.Current.ApplicationLifetime;
+            var screens = application.MainWindow.Screens.All;
+            
             if (screens.Count > 1)
                 for (int i = 0; i < screens.Count; i++)
                 {

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -206,7 +206,7 @@ namespace Observatory.UI.Views
             {
                 Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    var notifyWindow = new UI.Views.NotificationView() { DataContext = new UI.ViewModels.NotificationViewModel("Debug Notification", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras suscipit hendrerit libero ac scelerisque.") };
+                    var notifyWindow = new UI.Views.NotificationView() { DataContext = new UI.ViewModels.NotificationViewModel("Test Notification", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras suscipit hendrerit libero ac scelerisque.") };
                     notifyWindow.Show();
                 });
             };

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -194,8 +194,6 @@ namespace Observatory.UI.Views
                 Properties.Core.Default.Save();
             };
             
-            notificationGrid.AddControl(nativeNotifyCheckbox, 4, 0);
-
             Button notifyTestButton = new()
             { 
                 Content = "Test",
@@ -210,8 +208,6 @@ namespace Observatory.UI.Views
                     notifyWindow.Show();
                 });
             };
-
-            notificationGrid.AddControl(notifyTestButton, 4, 1);
 
             TextBlock notifyFontLabel = new() 
             { 
@@ -238,10 +234,6 @@ namespace Observatory.UI.Views
                 Properties.Core.Default.Save();
             };
             
-            notificationGrid.AddControl(notifyFontLabel, 0, 0);
-
-            notificationGrid.AddControl(notifyFontDropDown, 0, 1, 2);
-
             TextBlock monitorLabel = new()
             {
                 Text = "Display: ",
@@ -284,10 +276,6 @@ namespace Observatory.UI.Views
                 Properties.Core.Default.Save();
             };
 
-            notificationGrid.AddControl(monitorLabel, 2, 0);
-
-            notificationGrid.AddControl(monitorDropDown, 2, 1, 2);
-
             TextBlock cornerLabel = new()
             {
                 Text = "Corner: ",
@@ -318,10 +306,6 @@ namespace Observatory.UI.Views
                 Properties.Core.Default.Save();
             };
 
-            notificationGrid.AddControl(cornerLabel, 3, 0);
-
-            notificationGrid.AddControl(cornerDropDown, 3, 1, 2);
-
             TextBlock colourLabel = new()
             {
                 Text = "Colour: ",
@@ -333,9 +317,10 @@ namespace Observatory.UI.Views
 
             Egorozh.ColorPicker.Dialog.ColorPickerButton colourPickerButton = new()
             {
-                MinWidth = 200,
-                MinHeight = 25,
-                Color = Color.FromUInt32(Properties.Core.Default.NativeNotifyColour)
+                Width = 25,
+                Height = 25,
+                Color = Color.FromUInt32(Properties.Core.Default.NativeNotifyColour),
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Left
                 
             };
 
@@ -348,8 +333,17 @@ namespace Observatory.UI.Views
                 }
             };
 
-            notificationGrid.AddControl(colourLabel, 1, 0);
-            notificationGrid.AddControl(colourPickerButton, 1, 1);
+            notificationGrid.AddControl(monitorLabel, 0, 0);
+            notificationGrid.AddControl(monitorDropDown, 0, 1, 2);
+            notificationGrid.AddControl(cornerLabel, 1, 0);
+            notificationGrid.AddControl(cornerDropDown, 1, 1, 2);
+            notificationGrid.AddControl(notifyFontLabel, 2, 0);
+            notificationGrid.AddControl(notifyFontDropDown, 2, 1, 2);
+            notificationGrid.AddControl(colourLabel, 3, 0);
+            notificationGrid.AddControl(colourPickerButton, 3, 1);
+            notificationGrid.AddControl(notifyTestButton, 3, 1);
+            notificationGrid.AddControl(nativeNotifyCheckbox, 4, 0, 2);
+
 
             notificationExpander.Content = notificationGrid;
             

--- a/ObservatoryCore/UI/Views/NotificationView.axaml
+++ b/ObservatoryCore/UI/Views/NotificationView.axaml
@@ -5,25 +5,40 @@
         mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="150"
         x:Class="Observatory.UI.Views.NotificationView"
         ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="NoChrome"
+        ExtendClientAreaTitleBarHeightHint="-1"
         Title="Notification"
         Width="400" Height="150"
-        Topmost="True">
-  <StackPanel DataContext="{Binding Notification}">
-    <TextBlock 
-      Padding="10"
-      FontWeight="Bold"
-      FontSize="30"
-      FontFamily="Ebrima"
-      Text="{Binding Title}">
-      Title
-    </TextBlock>
-    <TextBlock 
-      Padding="20,0"
-      FontWeight="Normal"
-      FontSize="20"
-      FontFamily="Ebrima"
-      Text="{Binding Detail}">
-      Detail
-    </TextBlock>
-  </StackPanel>
+        MinWidth="400" MinHeight="150"
+        MaxWidth="400" MaxHeight="150"
+        Topmost="True"
+        SizeToContent="Height"
+        TransparencyLevelHint="AcrylicBlur"
+        Background="Transparent"
+        Focusable="False">
+  <Panel DataContext="{Binding Notification}">
+    <Border BorderBrush="{Binding Colour}" BorderThickness="4">
+      <StackPanel Width="400">
+        <TextBlock
+          Name="Title"
+          Padding="10"
+          FontWeight="Normal"
+          FontSize="30"
+          Foreground="{Binding Colour}"
+          Text="{Binding Title}">
+          Title
+        </TextBlock>
+        <TextBlock
+          Name="Detail"
+          Padding="20,0"
+          FontWeight="Normal"
+          FontSize="20"
+          TextWrapping="Wrap"
+          Foreground="{Binding Colour}"
+          Text="{Binding Detail}">
+          Detail
+        </TextBlock>
+      </StackPanel>
+    </Border>
+  </Panel>
 </Window>

--- a/ObservatoryCore/UI/Views/NotificationView.axaml.cs
+++ b/ObservatoryCore/UI/Views/NotificationView.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using System;
 using System.Runtime.InteropServices;
@@ -14,7 +15,7 @@ namespace Observatory.UI.Views
             SystemDecorations = SystemDecorations.None;
 
             MakeClickThrough(); //Platform specific, currently windows only.
-
+            
             int screen = Properties.Core.Default.NativeNotifyScreen;
             int corner = Properties.Core.Default.NativeNotifyCorner;
             string font = Properties.Core.Default.NativeNotifyFont;
@@ -36,16 +37,20 @@ namespace Observatory.UI.Views
             else
                 screenBounds = Screens.All[screen - 1].Bounds;
 
+            double scale = LayoutHelper.GetLayoutScale(this);
+            double scaleWidth = Width * scale;
+            double scaleHeight = Height * scale;
+
             switch (corner)
             {
                 default: case 0: 
-                    Position = screenBounds.BottomRight - new PixelPoint((int)Width + 50, (int)Height + 50);
+                    Position = screenBounds.BottomRight - new PixelPoint((int)scaleWidth + 50, (int)scaleHeight + 50);
                     break;
                 case 1:
-                    Position = screenBounds.BottomLeft - new PixelPoint(-50, (int)Height + 50);
+                    Position = screenBounds.BottomLeft - new PixelPoint(-50, (int)scaleHeight + 50);
                     break;
                 case 2:
-                    Position = screenBounds.TopRight - new PixelPoint((int)Width + 50, -50);
+                    Position = screenBounds.TopRight - new PixelPoint((int)scaleWidth + 50, -50);
                     break;
                 case 3:
                     Position = screenBounds.TopLeft + new PixelPoint(50, 50);

--- a/ObservatoryCore/UI/Views/NotificationView.axaml.cs
+++ b/ObservatoryCore/UI/Views/NotificationView.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using System;
+using System.Runtime.InteropServices;
 
 namespace Observatory.UI.Views
 {
@@ -10,11 +12,49 @@ namespace Observatory.UI.Views
         {
             InitializeComponent();
             SystemDecorations = SystemDecorations.None;
-            var screenBounds = Screens.Primary.Bounds;
-            Position = screenBounds.BottomRight - new PixelPoint((int)Width, (int)Height);
+
+            MakeClickThrough(); //Platform specific, currently windows only.
+
+            int screen = Properties.Core.Default.NativeNotifyScreen;
+            int corner = Properties.Core.Default.NativeNotifyCorner;
+            string font = Properties.Core.Default.NativeNotifyFont;
+            
+            if (font.Length > 0)
+            {
+                var titleText = this.Find<TextBlock>("Title");
+                var detailText = this.Find<TextBlock>("Detail");
+                var fontFamily = new Avalonia.Media.FontFamily(font);
+
+                titleText.FontFamily = fontFamily;
+                detailText.FontFamily = fontFamily;
+            }
+
+            PixelRect screenBounds;
+
+            if (screen == -1)
+                screenBounds = Screens.Primary.Bounds;
+            else
+                screenBounds = Screens.All[screen - 1].Bounds;
+
+            switch (corner)
+            {
+                default: case 0: 
+                    Position = screenBounds.BottomRight - new PixelPoint((int)Width + 50, (int)Height + 50);
+                    break;
+                case 1:
+                    Position = screenBounds.BottomLeft - new PixelPoint(-50, (int)Height + 50);
+                    break;
+                case 2:
+                    Position = screenBounds.TopRight - new PixelPoint((int)Width + 50, -50);
+                    break;
+                case 3:
+                    Position = screenBounds.TopLeft + new PixelPoint(50, 50);
+                    break;
+            }
+
             var timer = new System.Timers.Timer();
             timer.Elapsed += CloseNotification;
-            timer.Interval = 5000;
+            timer.Interval = 8000;
             timer.Start();
 #if DEBUG
             this.AttachDevTools();
@@ -33,5 +73,31 @@ namespace Observatory.UI.Views
         {
             AvaloniaXamlLoader.Load(this);
         }
+
+        private void MakeClickThrough()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var style = GetWindowLong(this.PlatformImpl.Handle.Handle, GWL_EXSTYLE);
+
+                //PlatformImpl not part of formal Avalonia API and may not be available in future versions.
+                SetWindowLong(this.PlatformImpl.Handle.Handle, GWL_EXSTYLE, style | WS_EX_LAYERED | WS_EX_TRANSPARENT);
+                SetLayeredWindowAttributes(this.PlatformImpl.Handle.Handle, 0, 255, LWA_ALPHA);
+            }
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern uint GetWindowLong(IntPtr hWnd, int nIndex);
+        [DllImport("user32.dll", SetLastError = true)]
+        static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, int uFlags);
+        [DllImport("user32.dll")]
+        static extern uint SetWindowLong(IntPtr hWnd, int nIndex, uint dwNewLong);
+        [DllImport("user32.dll")]
+        static extern bool SetLayeredWindowAttributes(IntPtr hwnd, uint crKey, byte bAlpha, uint dwFlags);
+
+        internal const int GWL_EXSTYLE = -20;
+        internal const int WS_EX_LAYERED = 0x80000;
+        internal const int LWA_ALPHA = 0x2;
+        internal const int WS_EX_TRANSPARENT = 0x00000020;
     }
 }

--- a/ObservatoryCore/UI/Views/NotificationView.axaml.cs
+++ b/ObservatoryCore/UI/Views/NotificationView.axaml.cs
@@ -32,7 +32,7 @@ namespace Observatory.UI.Views
 
             PixelRect screenBounds;
 
-            if (screen == -1)
+            if (screen == -1 || screen > Screens.All.Count)
                 screenBounds = Screens.Primary.Bounds;
             else
                 screenBounds = Screens.All[screen - 1].Bounds;


### PR DESCRIPTION
Change basic notification to something more presentable, and added several settings to control it.

Also snuck in the basic properties migration from older versions so they won't be lost between updates now that we have more of them. Still need to do this for plugin settings though.