### PR TITLE
Adding protection against a null parent reference.

### DIFF
--- a/ObservatoryExplorer/Explorer.cs
+++ b/ObservatoryExplorer/Explorer.cs
@@ -177,7 +177,7 @@ namespace Observatory.Explorer
 
             var results = DefaultCriteria.CheckInterest(scanEvent, SystemBodyHistory, BodySignalHistory, (ExplorerSettings)ExplorerWorker.Settings);
 
-            if (BarycentreHistory.ContainsKey(scanEvent.SystemAddress) && BarycentreHistory[scanEvent.SystemAddress].ContainsKey(scanEvent.Parent[0].Body))
+            if (BarycentreHistory.ContainsKey(scanEvent.SystemAddress) && scanEvent.Parent != null && BarycentreHistory[scanEvent.SystemAddress].ContainsKey(scanEvent.Parent[0].Body))
             {
                 ProcessScan(ConvertBarycentre(BarycentreHistory[scanEvent.SystemAddress][scanEvent.Parent[0].Body], scanEvent), readAll);
             }


### PR DESCRIPTION
Found this via ReadAll on my history. I can now process all my history without error.