### PR TITLE
Fix a couple of invalid thread exceptions in NativePopup notifications

### DIFF
--- a/ObservatoryCore/NativeNotification/NativePopup.cs
+++ b/ObservatoryCore/NativeNotification/NativePopup.cs
@@ -8,6 +8,7 @@ namespace Observatory.NativeNotification
 {
     public class NativePopup
     {
+        // TODO: This needs to be cleaned up when the app is closed.
         private Dictionary<Guid, NotificationView> notifications;
 
         public NativePopup()
@@ -48,13 +49,23 @@ namespace Observatory.NativeNotification
         public void CloseNotification(Guid guid)
         {
             if (notifications.ContainsKey(guid))
-                notifications[guid].Close();
+            {
+                Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    notifications[guid].Close();
+                });
+            }
         }
 
         public void UpdateNotification(Guid guid, NotificationArgs notificationArgs)
         {
             if (notifications.ContainsKey(guid))
-                notifications[guid].DataContext = new NotificationViewModel(notificationArgs);
+            {
+                Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    notifications[guid].DataContext = new NotificationViewModel(notificationArgs);
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
Manipulating active notifications must be done on the Avalonia UI thread. UpdateNotification and CloseNotification were not properly doing this.

Any plugin attempting to use persistent notifications would have encountered these errors.

NOTE: There is not yet hooks for cleaning up persistent/infinite timeout notifications when the APP is closed.