### PR TITLE
When pre-reading current system context, consider docked Carrier jumps

### DIFF
--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -119,7 +119,7 @@ namespace Observatory
                 foreach (var line in lines)
                 {
                     var eventType = JournalUtilities.GetEventType(line);
-                    if (eventType.Equals("FSDJump"))
+                    if (eventType.Equals("FSDJump") || (eventType.Equals("CarrierJump") && line.Contains("\"Docked\":true")))
                     {
                         // Reset, start collecting again.
                         lastSystemLines.Clear();


### PR DESCRIPTION
System context pre-reading logic previously assumed the player jumped into the current system in their own ship as a pilot. Arriving docked on their carrier was thus missed and may have resulted in processing more than one systems worth of context (or simply failing to pre-read context).