### PR TITLE
Add new Rendering controls for notifications, add missing forwarding

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -36,15 +36,18 @@ namespace Observatory.PluginManagement
 
             if (!LogMonitor.GetInstance.ReadAllInProgress())
             {
-                var handler = Notification;
-                handler?.Invoke(this, notificationArgs);
+                if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
+                {
+                    var handler = Notification;
+                    handler?.Invoke(this, notificationArgs);
+                }
 
-                if (Properties.Core.Default.NativeNotify)
+                if (Properties.Core.Default.NativeNotify && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVisual))
                 {
                     guid = NativePopup.InvokeNativeNotification(notificationArgs);
                 }
 
-                if (Properties.Core.Default.VoiceNotify)
+                if (Properties.Core.Default.VoiceNotify && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
                 {
                     NativeVoice.EnqueueAndAnnounce(notificationArgs);
                 }
@@ -60,7 +63,23 @@ namespace Observatory.PluginManagement
 
         public void UpdateNotification(Guid id, NotificationArgs notificationArgs)
         {
-            NativePopup.UpdateNotification(id, notificationArgs);
+            if (!LogMonitor.GetInstance.ReadAllInProgress())
+            {
+
+                if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
+                {
+                    var handler = Notification;
+                    handler?.Invoke(this, notificationArgs);
+                }
+
+                if (notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVisual))
+                    NativePopup.UpdateNotification(id, notificationArgs);
+
+                if (Properties.Core.Default.VoiceNotify && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
+                {
+                    NativeVoice.EnqueueAndAnnounce(notificationArgs);
+                }
+            }
         }
 
         /// <summary>

--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -54,5 +54,19 @@ namespace Observatory.Framework
         /// Specify window Y position as a percentage from upper left corner (overrides Core setting). Default -1.0 (use Core setting).
         /// </summary>
         public double YPos = -1.0;
+        /// <summary>
+        /// Specifies the desired renderings of the notification.
+        /// </summary>
+        public NotificationRendering Rendering = NotificationRendering.All;
+    }
+
+    [Flags]
+    public enum NotificationRendering
+    {
+        // These need to be multiples of 2 as they're used via masking.
+        NativeVisual = 1,
+        NativeVocal = 2,
+        PluginNotifier = 4,
+        All = (NativeVisual | NativeVocal | PluginNotifier)
     }
 }


### PR DESCRIPTION
Plugins authors can now optionally specify what ways their notifications are rendered (subject, of course, to user preferences/settings). The default is to render notifications in all available channels. Examples:
- Show native pop-up window only (ie. no voice/plugin notifiers)
- Disallow other plugin notifiers

This does not support selection of notifier plugins.

Furthermore, persistent notification updates were not previously being forwarded to anything but the native popup notifier. Now plugins and native voice are also supported (subject to user preferences) and respect the new rendering controls added here. There is currently no concept of closing notifications for the native voice or plugin-based notifiers.