### PR TITLE
Show notification with genetic sampling status while in progress

### DIFF
--- a/ObservatoryBotanist/Botanist.cs
+++ b/ObservatoryBotanist/Botanist.cs
@@ -30,6 +30,7 @@ namespace Observatory.Botanist
         ObservableCollection<object> GridCollection;
         private PluginUI pluginUI;
         private bool readAllInProgress = false;
+        private Guid? samplerStatusNotification = null;
 
         public string Name => "Observatory Botanist";
 
@@ -98,6 +99,25 @@ namespace Observatory.Botanist
                             {
                                 case ScanOrganicType.Log:
                                 case ScanOrganicType.Sample:
+                                    if (!readAllInProgress)
+                                    {
+                                        NotificationArgs args = new()
+                                        {
+                                            Title = scanOrganic.Species_Localised,
+                                            Detail = string.Format("Sample {0} of 3", scanOrganic.ScanType == ScanOrganicType.Log ? 1 : 2),
+                                            Rendering = NotificationRendering.NativeVisual,
+                                            Timeout = 0,
+                                        };
+                                        if (samplerStatusNotification == null)
+                                        {
+                                            samplerStatusNotification = Core.SendNotification(args);
+                                        }
+                                        else
+                                        {
+                                            Core.UpdateNotification(samplerStatusNotification.Value, args);
+                                        }
+                                    }
+
                                     if (!bioPlanet.speciesFound.Contains(scanOrganic.Species_Localised))
                                     {
                                         bioPlanet.speciesFound.Add(scanOrganic.Species_Localised);
@@ -107,6 +127,12 @@ namespace Observatory.Botanist
                                     if (!bioPlanet.speciesAnalysed.Contains(scanOrganic.Species_Localised))
                                     {
                                         bioPlanet.speciesAnalysed.Add(scanOrganic.Species_Localised);
+                                    }
+
+                                    if (samplerStatusNotification != null)
+                                    {
+                                        Core.CancelNotification(samplerStatusNotification.Value);
+                                        samplerStatusNotification = null;
                                     }
                                     break;
                             }

--- a/ObservatoryBotanist/BotanistSettings.cs
+++ b/ObservatoryBotanist/BotanistSettings.cs
@@ -1,0 +1,15 @@
+﻿using Observatory.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.Botanist
+{
+    class BotanistSettings
+    {
+        [SettingDisplayName("Enable Sampler Status Overlay")]
+        public bool OverlayEnabled { get; set; }
+    }
+}


### PR DESCRIPTION
When first sample is taken, the notification is displayed showing what was sampled and number of samples taken. Number of samples taken is updated on the second sample. Notification is removed when the final sample is taken.