### PR TITLE
Revert "Close Ring Proximity criteria: Prevent it from triggering on a belt"

### DIFF
--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -68,7 +68,7 @@ namespace Observatory.Explorer
                     foreach (var ring in parent.Rings)
                     {
                         var separation = Math.Min(Math.Abs(scan.SemiMajorAxis - ring.OuterRad), Math.Abs(ring.InnerRad - scan.SemiMajorAxis));
-                        if (separation < scan.Radius * 10 && !ring.Name.Contains("Belt"))
+                        if (separation < scan.Radius * 10)
                         {
                             results.Add("Close Ring Proximity", $"Orbit: {scan.SemiMajorAxis / 1000:N0}km, Radius: {scan.Radius / 1000:N0}km, Distance from ring: {separation / 1000:N0}km");
                         }


### PR DESCRIPTION
Reverts Xjph/ObservatoryCore#56

I wasn't thinking when I merged this. This issue has been discussed on the forums with the conclusion being to leave it in as intended functionality. Close *belt* proximity can give unique [views of planets from asteroid clusters.](https://forums.frontier.co.uk/threads/elite-observatory-search-your-journal-for-potentially-interesting-objects-or-notify-you-of-new-ones-on-the-fly-while-exploring.521544/page-20#post-8192352)