### PR TITLE
Add event-based LogMonitor state changes to better handle batch reads

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -11,7 +11,7 @@ namespace Observatory.PluginManagement
 
         private readonly NativeVoice NativeVoice;
         private readonly NativePopup NativePopup;
-        private LogMonitorState currentLogMonitorState = LogMonitorState.None;
+        private LogMonitorState currentLogMonitorState = LogMonitorState.Idle;
 
         public PluginCore()
         {
@@ -147,17 +147,9 @@ namespace Observatory.PluginManagement
 
         public bool IsLogMonitorBatchReading
         {
-            get
-            {
-                switch(currentLogMonitorState)
-                {
-                    case LogMonitorState.ReadAllBatch:
-                    case LogMonitorState.PreReadBatch:
-                        return true;
-                }
-                return false;
-            }
+            get => LogMonitorStateChangedEventArgs.IsBatchRead(currentLogMonitorState);
         }
+
         public event EventHandler<NotificationArgs> Notification;
     }
 }

--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -11,11 +11,17 @@ namespace Observatory.PluginManagement
 
         private readonly NativeVoice NativeVoice;
         private readonly NativePopup NativePopup;
+        private LogMonitorState currentLogMonitorState = LogMonitorState.None;
 
         public PluginCore()
         {
             NativeVoice = new();
             NativePopup = new();
+        }
+
+        internal void OnLogMonitorStateChanged(object sender, LogMonitorStateChangedEventArgs e)
+        {
+            currentLogMonitorState = e.NewState;
         }
 
         public string Version => System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
@@ -34,7 +40,7 @@ namespace Observatory.PluginManagement
         {
             var guid = Guid.Empty;
 
-            if (!LogMonitor.GetInstance.ReadAllInProgress())
+            if (!IsLogMonitorBatchReading)
             {
                 if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
                 {
@@ -63,7 +69,7 @@ namespace Observatory.PluginManagement
 
         public void UpdateNotification(Guid id, NotificationArgs notificationArgs)
         {
-            if (!LogMonitor.GetInstance.ReadAllInProgress())
+            if (!IsLogMonitorBatchReading)
             {
 
                 if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
@@ -134,6 +140,24 @@ namespace Observatory.PluginManagement
             get => Observatory.HttpClient.Client;
         }
 
+        public LogMonitorState CurrentLogMonitorState
+        {
+            get => currentLogMonitorState;
+        }
+
+        public bool IsLogMonitorBatchReading
+        {
+            get
+            {
+                switch(currentLogMonitorState)
+                {
+                    case LogMonitorState.ReadAllBatch:
+                    case LogMonitorState.PreReadBatch:
+                        return true;
+                }
+                return false;
+            }
+        }
         public event EventHandler<NotificationArgs> Notification;
     }
 }

--- a/ObservatoryCore/PluginManagement/PluginEventHandler.cs
+++ b/ObservatoryCore/PluginManagement/PluginEventHandler.cs
@@ -61,6 +61,21 @@ namespace Observatory.PluginManagement
             }
         }
 
+        internal void OnLogMonitorStateChanged(object sender, LogMonitorStateChangedEventArgs e)
+        {
+            foreach (var worker in observatoryWorkers)
+            {
+                try
+                {
+                    worker.LogMonitorStateChanged(e);
+                }
+                catch (Exception ex)
+                {
+                    RecordError(ex, worker.Name, "LogMonitorStateChanged event");
+                }
+            }
+        }
+
         public void OnNotificationEvent(object source, NotificationArgs notificationArgs)
         {
             foreach (var notifier in observatoryNotifiers)

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -46,8 +46,10 @@ namespace Observatory.PluginManagement
 
             logMonitor.JournalEntry += pluginHandler.OnJournalEvent;
             logMonitor.StatusUpdate += pluginHandler.OnStatusUpdate;
+            logMonitor.LogMonitorStateChanged += pluginHandler.OnLogMonitorStateChanged;
 
             var core = new PluginCore();
+            logMonitor.LogMonitorStateChanged += core.OnLogMonitorStateChanged;
 
             List<IObservatoryPlugin> errorPlugins = new();
             

--- a/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
@@ -65,8 +65,10 @@ namespace Observatory.UI.ViewModels
 
         public void ReadAll()
         {
+            // TODO(fredjk_gh): remove.
             SetWorkerReadAllState(true);
             LogMonitor.GetInstance.ReadAllJournals();
+            // TODO(fredjk_gh): remove.
             SetWorkerReadAllState(false);
         }
 
@@ -82,8 +84,10 @@ namespace Observatory.UI.ViewModels
             else
             {
                 // HACK: Find a better way of suppressing notifications when pre-reading.
+                // TODO(fredjk_gh): remove.
                 SetWorkerReadAllState(true);
                 logMonitor.Start();
+                // TODO(fredjk_gh): remove.
                 SetWorkerReadAllState(false);
                 ToggleButtonText = "Stop Monitor";
             }
@@ -138,6 +142,7 @@ namespace Observatory.UI.ViewModels
             get { return tabs; }
         }
 
+        // TODO(fredjk_gh): remove.
         private void SetWorkerReadAllState(bool isReadingAll)
         {
             foreach (var worker in workers)

--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -70,13 +70,14 @@ namespace Observatory.Framework
         All = (NativeVisual | NativeVocal | PluginNotifier)
     }
 
-    public enum LogMonitorState
+    [Flags]
+    public enum LogMonitorState : uint
     {
-        None, // This is used only for startup.
-        Idle, // Monitoring is stopped
-        ReadAllBatch, // Performing a batch read of history. Formerly known as "read-all".
-        PreReadBatch, // Currently pre-reading current system context, if enabled, prior to RealTime monitoring
-        Realtime, // Real-time monitoring is active
+        // These need to be multiples of 2 as they're used via masking.
+        Idle = 0, // Monitoring is stopped
+        Realtime = 1, // Real-time monitoring is active
+        Batch = 2, // Performing a batch read of history
+        PreRead = 4 // Currently pre-reading current system context (a batch read)
     }
 
     /// <summary>
@@ -101,7 +102,7 @@ namespace Observatory.Framework
         /// <returns>A boolean; True iff the state provided represents a batch-mode read.</returns>
         public static bool IsBatchRead(LogMonitorState state)
         {
-            return state == LogMonitorState.ReadAllBatch || state == LogMonitorState.PreReadBatch;
+            return (state & (LogMonitorState.Batch | LogMonitorState.PreRead)) > 0;
         }
     }
 }

--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -18,7 +18,7 @@ namespace Observatory.Framework
         /// </summary>
         public object journalEvent;
     }
-    
+
     /// <summary>
     /// Provides values used as arguments for Observatory notification events.
     /// </summary>
@@ -68,5 +68,40 @@ namespace Observatory.Framework
         NativeVocal = 2,
         PluginNotifier = 4,
         All = (NativeVisual | NativeVocal | PluginNotifier)
+    }
+
+    public enum LogMonitorState
+    {
+        None, // This is used only for startup.
+        Idle, // Monitoring is stopped
+        ReadAllBatch, // Performing a batch read of history. Formerly known as "read-all".
+        PreReadBatch, // Currently pre-reading current system context, if enabled, prior to RealTime monitoring
+        Realtime, // Real-time monitoring is active
+    }
+
+    /// <summary>
+    /// Provides information about a LogMonitor state transition.
+    /// </summary>
+    public class LogMonitorStateChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The previous LogMonitor state.
+        /// </summary>
+        public LogMonitorState PreviousState;
+
+        /// <summary>
+        /// The new, current LogMonitor state.
+        /// </summary>
+        public LogMonitorState NewState;
+
+        /// <summary>
+        /// Determins if the given state is a batch read of any form.
+        /// </summary>
+        /// <param name="state">The state to evaluate</param>
+        /// <returns>A boolean; True iff the state provided represents a batch-mode read.</returns>
+        public static bool IsBatchRead(LogMonitorState state)
+        {
+            return state == LogMonitorState.ReadAllBatch || state == LogMonitorState.PreReadBatch;
+        }
     }
 }

--- a/ObservatoryFramework/Interfaces.cs
+++ b/ObservatoryFramework/Interfaces.cs
@@ -77,10 +77,18 @@ namespace Observatory.Framework.Interfaces
         { }
 
         /// <summary>
+        /// Called when the LogMonitor changes state. Useful for suppressing output in certain situations
+        /// such as batch reads (ie. "Read all") or responding to other state transitions.
+        /// </summary>
+        public void LogMonitorStateChanged(LogMonitorStateChangedEventArgs eventArgs)
+        { }
+
+        /// <summary>
         /// Method called when the user begins "Read All" journal processing, before any journal events are sent.<br/>
         /// Used to track if a "Read All" operation is in progress or not to avoid unnecessary processing or notifications.<br/>
         /// Can be omitted for plugins which do not require the distinction.
         /// </summary>
+        [Obsolete] // Replaced by LogMonitorStateChanged 
         public void ReadAllStarted()
         { }
 
@@ -89,6 +97,7 @@ namespace Observatory.Framework.Interfaces
         /// Used to track if a "Read All" operation is in progress or not to avoid unnecessary processing or notifications.<br/>
         /// Can be omitted for plugins which do not require the distinction.
         /// </summary>
+        [Obsolete] // Replaced by LogMonitorStateChanged
         public void ReadAllFinished()
         { }
     }
@@ -175,5 +184,15 @@ namespace Observatory.Framework.Interfaces
         /// Shared application HttpClient object. Provided so that plugins can adhere to .NET recommended behaviour of a single HttpClient object per application.
         /// </summary>
         public HttpClient HttpClient { get; }
+
+        /// <summary>
+        /// Returns the current LogMonitor state.
+        /// </summary>
+        public LogMonitorState CurrentLogMonitorState { get; }
+
+        /// <summary>
+        /// Returns true if the current LogMonitor state represents a batch-read mode.
+        /// </summary>
+        public bool IsLogMonitorBatchReading { get; }
     }
 }


### PR DESCRIPTION
Pre-reading hackily used read-all to suppress notifications. But that broke some assumptions about what read-all meant. Furthermore, the Core UI told plugins about read-all rather than the log monitor telling them -- which is really what should be telling them.

To address these concerns, LogMonitor now provides an event that both the PluginCore and PluginEventHandler listens to for tracking logging state allowing more granular information about the activities of LogMonitor, including distinguishing between ReadAll and Pre-read batches. Plugins no longer need to track if LogMonitor is in batch-read mode or not -- PluginCore now provides it. 

I've also converted all built-in plugins to use the new event-based system. The old system is marked deprecated and will go away once other known contributed plugins have converted to the new system.