### PR TITLE
Revert PluginCore use of event listening for current LogMonitor state

### DIFF
--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -38,6 +38,13 @@ namespace Observatory
 
         #endregion
 
+        #region Public properties
+        public LogMonitorState CurrentState
+        {
+            get => currentState;
+        }
+        #endregion
+
         #region Public Methods
 
         public void Start()

--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -11,17 +11,11 @@ namespace Observatory.PluginManagement
 
         private readonly NativeVoice NativeVoice;
         private readonly NativePopup NativePopup;
-        private LogMonitorState currentLogMonitorState = LogMonitorState.Idle;
 
         public PluginCore()
         {
             NativeVoice = new();
             NativePopup = new();
-        }
-
-        internal void OnLogMonitorStateChanged(object sender, LogMonitorStateChangedEventArgs e)
-        {
-            currentLogMonitorState = e.NewState;
         }
 
         public string Version => System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
@@ -142,12 +136,12 @@ namespace Observatory.PluginManagement
 
         public LogMonitorState CurrentLogMonitorState
         {
-            get => currentLogMonitorState;
+            get => LogMonitor.GetInstance.CurrentState;
         }
 
         public bool IsLogMonitorBatchReading
         {
-            get => LogMonitorStateChangedEventArgs.IsBatchRead(currentLogMonitorState);
+            get => LogMonitorStateChangedEventArgs.IsBatchRead(LogMonitor.GetInstance.CurrentState);
         }
 
         public event EventHandler<NotificationArgs> Notification;

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -49,7 +49,6 @@ namespace Observatory.PluginManagement
             logMonitor.LogMonitorStateChanged += pluginHandler.OnLogMonitorStateChanged;
 
             var core = new PluginCore();
-            logMonitor.LogMonitorStateChanged += core.OnLogMonitorStateChanged;
 
             List<IObservatoryPlugin> errorPlugins = new();
             


### PR DESCRIPTION
The order that listeners get notified isn't deterministic and as a result plugins which read the current state from PluginCore during the handling of a state change event may read a stale state resulting in unexpected results. PluginCore now reads a property directly from LogMonitor to avoid such inconsistencies.