### PR TITLE
Fix file ordering assumptions which were broken by U11

### DIFF
--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using Observatory.Framework;
 using Observatory.Framework.Files;
 
@@ -98,7 +99,7 @@ namespace Observatory
             SetLogMonitorState(currentState | LogMonitorState.Batch);
 
             DirectoryInfo logDirectory = GetJournalFolder(path);
-            var files = logDirectory.GetFiles("Journal.*.??.log");
+            var files = GetJournalFilesOrdered(logDirectory);
             var readErrors = new List<(Exception ex, string file, string line)>();
             foreach (var file in files)
             {
@@ -117,7 +118,7 @@ namespace Observatory
             SetLogMonitorState(currentState | LogMonitorState.PreRead);
 
             DirectoryInfo logDirectory = GetJournalFolder(Properties.Core.Default.JournalFolder);
-            var files = logDirectory.GetFiles("Journal.*.??.log");
+            var files = GetJournalFilesOrdered(logDirectory);
             
             // Read at most the last two files (in case we were launched after the game and the latest
             // journal is mostly empty) but keeping only the lines since the last FSDJump.
@@ -425,7 +426,9 @@ namespace Observatory
                 {
                     FileInfo fileToPoke = null;
 
-                    foreach (var file in journalFolder.GetFiles("Journal.*.??.log"))
+                    // TODO: If we now have reliable file ordering guarantees, do we need this loop? Could we
+                    // just poke file in the last slot of the array returned by GetJournalFilesOrdered?
+                    foreach (var file in GetJournalFilesOrdered(journalFolder))
                     {
                         if (fileToPoke == null || string.Compare(file.Name, fileToPoke.Name) > 0)
                         {
@@ -454,6 +457,47 @@ namespace Observatory
             {
                 Marshal.FreeCoTaskMem(pathPtr);
             }
+        }
+
+        private Regex datePartRe = new(@"Journal\.(.+)\.\d+\.log", RegexOptions.Compiled);
+        private Regex numericDateRe = new(@"^\d+$", RegexOptions.Compiled);
+
+        FileInfo[] GetJournalFilesOrdered(DirectoryInfo journalFolder)
+        {
+            // Sort files by Elite's timestamp to deal with different filename formats.
+            return journalFolder.GetFiles("Journal.*.??.log")
+                .ToDictionary(f => TimestampFromFile(f), f => f)
+                .OrderBy(kvp => kvp.Key)
+                .Select(kvp => kvp.Value)
+                .ToArray();
+        }
+
+        private long TimestampFromFile(FileInfo f)
+        {
+            string filename = f.Name;
+
+            Match datePart = datePartRe.Match(filename);
+            if (!datePart.Success)
+            {
+                // No date part? Unexpected filename.
+                return 0;
+            }
+
+            DateTimeOffset timeStamp;
+            if (numericDateRe.Match(datePart.Groups[1].Value).Success)
+            {
+                // This is a numeric date from old journals in the format: yyMMddHHmmss
+                timeStamp = DateTimeOffset.ParseExact(datePart.Groups[1].Value, "yyMMddHHmmss", null);
+            }
+            // Try parse this as a new style date of the format: yyyy-MM-ddTHHmmss
+            else if (!DateTimeOffset.TryParseExact(datePart.Groups[1].Value, "yyyy-MM-ddTHHmmss", null, System.Globalization.DateTimeStyles.None, out timeStamp))
+            {
+                // Unfamiliar date format.
+                return 0;
+            }
+
+            // Give me a good, ol' fashioned unix timestamp...
+            return timeStamp.ToUnixTimeSeconds();
         }
 
         [DllImport("shell32.dll", CharSet = CharSet.Auto)]


### PR DESCRIPTION
With U11's new filename format for journal files, files don't sort right anymore and so the incorrect context was read during pre-reading, journals were read out-of-order during read-all or the wrong file was poked by JournalPoke for real-time. It seems that real-time still worked well enough (presumably the game client flushes journals semi reliably?)

Either way, ordering can be better guaranteed now.