### PR TITLE
Distinguish Close Belt proximity and Close Ring proximity criteria

### DIFF
--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -70,7 +70,9 @@ namespace Observatory.Explorer
                         var separation = Math.Min(Math.Abs(scan.SemiMajorAxis - ring.OuterRad), Math.Abs(ring.InnerRad - scan.SemiMajorAxis));
                         if (separation < scan.Radius * 10)
                         {
-                            results.Add("Close Ring Proximity", $"Orbit: {scan.SemiMajorAxis / 1000:N0}km, Radius: {scan.Radius / 1000:N0}km, Distance from ring: {separation / 1000:N0}km");
+                            var ringTypeName = ring.Name.Contains("Belt") ? "Belt" : "Ring";
+                            results.Add($"Close {ringTypeName} Proximity",
+                                $"Orbit: {scan.SemiMajorAxis / 1000:N0}km, Radius: {scan.Radius / 1000:N0}km, Distance from {ringTypeName.ToLower()}: {separation / 1000:N0}km");
                         }
                     }
                 }


### PR DESCRIPTION
If it's a belt, report it as a belt instead of a ring.

See 7c209efb9f1e4eeb248b36d65463aa10e6f2f70e for context.