### PR TITLE
Fix a "Call from invalid thread" exception.

### DIFF
--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -111,7 +111,6 @@ namespace Observatory.UI.Views
             {
                 var dataContext = ((ViewModels.BasicUIViewModel)dataGrid.DataContext).BasicUIGrid;
                 dataContext.CollectionChanged += ScrollToLast;
-                
             }
         }
 
@@ -121,7 +120,10 @@ namespace Observatory.UI.Views
             if (e.Action != System.Collections.Specialized.NotifyCollectionChangedAction.Add || UIType != PluginUI.UIType.Basic || dataGrid == null || !(sender is ObservableCollection<object>))
                 return;
             var dataContext = (ObservableCollection<object>)sender;
-            dataGrid.ScrollIntoView(dataContext[dataContext.Count - 1], null);
+            Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                dataGrid.ScrollIntoView(dataContext[dataContext.Count - 1], null);
+            });
         }
 
         private Grid GenerateCoreUI()


### PR DESCRIPTION
Random occurrence triggered by a plugin's grid update. It's either fairly rare (related to something I was doing in-app) or new with a recent update to the plugin that caused it (just updated it last night).