### PR TITLE
Expose core error logger to plugins and report custom criteria errors

### DIFF
--- a/ObservatoryCore/ObservatoryCore.cs
+++ b/ObservatoryCore/ObservatoryCore.cs
@@ -30,8 +30,9 @@ namespace Observatory
         {
             var docPath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments);
             var errorMessage = new System.Text.StringBuilder();
+            var timestamp = DateTime.Now.ToString("G");
             errorMessage
-                .AppendLine($"Error encountered in Elite Observatory {context}.")
+                .AppendLine($"[{timestamp}] Error encountered in Elite Observatory {context}")
                 .AppendLine(FormatExceptionMessage(ex))
                 .AppendLine();
             System.IO.File.AppendAllText(docPath + System.IO.Path.DirectorySeparatorChar + "ObservatoryErrorLog.txt", errorMessage.ToString());

--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -21,6 +21,14 @@ namespace Observatory.PluginManagement
 
         public string Version => System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
 
+        public Action<Exception, String> GetPluginErrorLogger(IObservatoryPlugin plugin)
+        {
+            return (ex, context) =>
+            {
+                ObservatoryCore.LogError(ex, $"from plugin {plugin.ShortName} {context}");
+            };
+        }
+
         public Status GetStatus()
         {
             throw new NotImplementedException();

--- a/ObservatoryExplorer/Explorer.cs
+++ b/ObservatoryExplorer/Explorer.cs
@@ -29,7 +29,7 @@ namespace Observatory.Explorer
             ExplorerWorker = explorerWorker;
             ObservatoryCore = core;
             Results = results;
-            CustomCriteriaManager = new();
+            CustomCriteriaManager = new(core.GetPluginErrorLogger(explorerWorker));
             CriteriaLastModified = new DateTime(0);
         }
 

--- a/ObservatoryFramework/Interfaces.cs
+++ b/ObservatoryFramework/Interfaces.cs
@@ -175,6 +175,13 @@ namespace Observatory.Framework.Interfaces
         public string Version { get; }
 
         /// <summary>
+        /// Returns a delegate for logging an error for the calling plugin. A plugin can wrap this method
+        /// or pass it along to its collaborators.
+        /// </summary>
+        /// <param name="plugin">The calling plugin</param>
+        public Action<Exception, String> GetPluginErrorLogger (IObservatoryPlugin plugin);
+
+        /// <summary>
         /// Perform an action on the current Avalonia UI thread.
         /// </summary>
         /// <param name="action"></param>

--- a/ObservatoryHerald/HeraldNotifier.cs
+++ b/ObservatoryHerald/HeraldNotifier.cs
@@ -55,7 +55,7 @@ namespace Observatory.Herald
         {
             var speechManager = new SpeechRequestManager(
                 heraldSettings, observatoryCore.HttpClient, observatoryCore.PluginStorageFolder, observatoryCore.GetPluginErrorLogger(this));
-            heraldSpeech = new HeraldQueue(speechManager);
+            heraldSpeech = new HeraldQueue(speechManager, observatoryCore.GetPluginErrorLogger(this));
             heraldSettings.Test = TestVoice;
         }
 

--- a/ObservatoryHerald/HeraldNotifier.cs
+++ b/ObservatoryHerald/HeraldNotifier.cs
@@ -53,7 +53,8 @@ namespace Observatory.Herald
         }
         public void Load(IObservatoryCore observatoryCore)
         {
-            var speechManager = new SpeechRequestManager(heraldSettings, observatoryCore.HttpClient, observatoryCore.PluginStorageFolder);
+            var speechManager = new SpeechRequestManager(
+                heraldSettings, observatoryCore.HttpClient, observatoryCore.PluginStorageFolder, observatoryCore.GetPluginErrorLogger(this));
             heraldSpeech = new HeraldQueue(speechManager);
             heraldSettings.Test = TestVoice;
         }

--- a/ObservatoryHerald/SpeechRequestManager.cs
+++ b/ObservatoryHerald/SpeechRequestManager.cs
@@ -52,7 +52,19 @@ namespace Observatory.Herald
 
             var audioFilename = cacheLocation + ssmlHash + ".mp3";
 
-            if (!File.Exists(audioFilename))
+            FileInfo audioFileInfo = null;
+            if (File.Exists(audioFilename))
+            {
+                audioFileInfo = new FileInfo(audioFilename);
+                if (audioFileInfo.Length == 0)
+                {
+                    File.Delete(audioFilename);
+                    audioFileInfo = null;
+                }
+            }
+
+
+            if (audioFileInfo == null)
             {
                 using StringContent request = new(ssml)
                 {
@@ -74,10 +86,10 @@ namespace Observatory.Herald
                 {
                     throw new PluginException("Herald", "Unable to retrieve audio data.", new Exception(response.StatusCode.ToString() + ": " + response.ReasonPhrase));
                 }
-
+                audioFileInfo = new FileInfo(audioFilename);
             }
 
-            UpdateAndPruneCache(new FileInfo(audioFilename));
+            UpdateAndPruneCache(audioFileInfo);
                         
             return audioFilename;
         }

--- a/ObservatoryHerald/SpeechRequestManager.cs
+++ b/ObservatoryHerald/SpeechRequestManager.cs
@@ -19,15 +19,18 @@ namespace Observatory.Herald
         private string ApiEndpoint;
         private DirectoryInfo cacheLocation;
         private int cacheSize;
-        
-        internal SpeechRequestManager(HeraldSettings settings, HttpClient httpClient, string cacheFolder)
+        private Action<Exception, String> ErrorLogger;
+
+        internal SpeechRequestManager(
+            HeraldSettings settings, HttpClient httpClient, string cacheFolder, Action<Exception, String> errorLogger)
         {
             ApiKey = ObservatoryAPI.ApiKey;
             ApiEndpoint = settings.ApiEndpoint;
             this.httpClient = httpClient;
             cacheSize = Math.Max(settings.CacheSize, 1);
             cacheLocation = new DirectoryInfo(cacheFolder);
-                        
+            ErrorLogger = errorLogger;
+
             if (!Directory.Exists(cacheLocation.FullName))
             {
                 Directory.CreateDirectory(cacheLocation.FullName);
@@ -231,6 +234,7 @@ namespace Observatory.Herald
                 {
                     Console.WriteLine(ex.Message);
                     cacheIndex = new();
+                    ErrorLogger(ex, "deserializing CacheIndex.json");
                 }
             }
             else


### PR DESCRIPTION
Fixes #77

This adds an error logging method on the IObservatoryCore interface that writes the exception details to ObservatoryCore's central error log (found in `${Documents}/ObservatoryErrorLog.txt`). In addition, added a timestamp to each error log.

Also updates the Explorer to report Custom Criteria file load errors and execution errors to the log. Also updates HeraldNotifier to report CacheIndex.json parse failures to the error log as well.