### PR TITLE
added HighValueMappable checks

### DIFF
--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -9,6 +9,18 @@ namespace Observatory.Explorer
 {
     internal static class DefaultCriteria
     {
+        private static IList<string> HighValueNonTerraformablePlanetClasses = new string[] {
+            "Earthlike body",
+            "Ammonia world",
+            "Water world",
+        };
+
+        private static IList<string> HighValueTerraformablePlanetClasses = new string[] {
+            "Water world",
+            "High metal content body",
+            "Rocky body",
+        };
+
         public static List<(string Description, string Detail, bool SystemWide)> CheckInterest(Scan scan, Dictionary<ulong, Dictionary<int, Scan>> scanHistory, Dictionary<ulong, Dictionary<int, FSSBodySignals>> signalHistory, ExplorerSettings settings)
         {
             List<(string, string, bool)> results = new();
@@ -46,6 +58,20 @@ namespace Observatory.Explorer
             }
             #endregion
 
+            #region Value Checks
+            if (settings.HighValueMappable)
+            {
+                if (HighValueTerraformablePlanetClasses.Contains(scan.PlanetClass) && scan.TerraformState?.Length > 0)
+                {
+                    results.Add("High-Value Terraformable");
+                }
+                if (HighValueNonTerraformablePlanetClasses.Contains(scan.PlanetClass) && scan.TerraformState?.Length == 0)
+                {
+                    results.Add("High-Value Non-Terraformable");
+                }
+            }
+            #endregion
+            
             #region Parent Relative Checks
 
             if (scan.SystemAddress != 0 && scan.SemiMajorAxis != 0 &&

--- a/ObservatoryExplorer/ExplorerSettings.cs
+++ b/ObservatoryExplorer/ExplorerSettings.cs
@@ -80,6 +80,9 @@ namespace Observatory.Explorer
         [SettingDisplayName("All Surface Mats In System")]
         public bool GoldSystem { get; set; }
 
+        [SettingDisplayName("High-Value Mapping")]
+        public bool HighValueMappable { get; set; }
+
         [SettingDisplayName("Enable Custom Criteria")]
         public bool EnableCustomCriteria { get; set; }
 


### PR DESCRIPTION
Added an Explorer criteria "High-Value Mapping" that notifies when planetclass is:
* Earthlike body
* Ammonia world
* Water world (terraformable or not)
* High metal content body (terraformable)
* Rocky body (terraformable)

![image](https://user-images.githubusercontent.com/860672/166863777-5d8538d0-8b92-4ab7-ab47-e1a676623475.png)

![image](https://user-images.githubusercontent.com/860672/166863793-741ab570-76f8-4261-b24d-c53008c8b236.png)
