### PR TITLE
Export, plugin archive install, and herald cache race condition fixes

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -190,6 +190,8 @@ namespace Observatory.PluginManagement
 
             if (Directory.Exists(pluginPath))
             {
+                ExtractPlugins(pluginPath);
+
                 //Temporarily skipping signature checks. Need to do this the right way later.
                 var pluginLibraries = Directory.GetFiles($"{AppDomain.CurrentDomain.BaseDirectory}{Path.DirectorySeparatorChar}plugins", "*.dll");
                 //var coreToken = Assembly.GetExecutingAssembly().GetName().GetPublicKeyToken();
@@ -239,6 +241,18 @@ namespace Observatory.PluginManagement
                 }
             }
             return errorList;
+        }
+
+        private static void ExtractPlugins(string pluginFolder)
+        {
+            var files = Directory.GetFiles(pluginFolder, "*.zip")
+                .Concat(Directory.GetFiles(pluginFolder, "*.eop"));
+
+            foreach (var file in files)
+            {
+                System.IO.Compression.ZipFile.ExtractToDirectory(file, pluginFolder, true);
+                File.Delete(file);
+            }
         }
 
         private static string LoadPluginAssembly(string dllPath, List<(IObservatoryWorker plugin, PluginStatus signed)> workers, List<(IObservatoryNotifier plugin, PluginStatus signed)> notifiers)

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -251,7 +251,11 @@ namespace Observatory.PluginManagement
 
         private static string LoadPluginAssembly(string dllPath, List<(IObservatoryWorker plugin, PluginStatus signed)> workers, List<(IObservatoryNotifier plugin, PluginStatus signed)> notifiers)
         {
+
+            string recursionGuard = string.Empty;
+
             System.Runtime.Loader.AssemblyLoadContext.Default.Resolving += (context, name) => {
+            
                 if (name.Name.EndsWith("resources"))
                 {
                     return null;
@@ -270,7 +274,17 @@ namespace Observatory.PluginManagement
                     return context.LoadFromAssemblyPath(foundDlls[0]);
                 }
 
-                return context.LoadFromAssemblyName(name);
+                if (name.Name != recursionGuard)
+                {
+                    recursionGuard = name.Name;
+
+                    return context.LoadFromAssemblyName(name);
+                }
+                else
+                {
+                    throw new Exception("Unable to load assembly " + name.Name);
+                }
+    
             };
 
             var pluginAssembly = System.Runtime.Loader.AssemblyLoadContext.Default.LoadFromAssemblyPath(new FileInfo(dllPath).FullName);

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -244,8 +244,15 @@ namespace Observatory.PluginManagement
 
             foreach (var file in files)
             {
-                System.IO.Compression.ZipFile.ExtractToDirectory(file, pluginFolder, true);
-                File.Delete(file);
+                try
+                {
+                    System.IO.Compression.ZipFile.ExtractToDirectory(file, pluginFolder, true);
+                    File.Delete(file);
+                }
+                catch 
+                { 
+                    // Just ignore files that don't extract successfully.
+                }
             }
         }
 

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -174,12 +174,6 @@ namespace Observatory.PluginManagement
             Properties.Core.Default.Save();
         }
 
-        //private static string GetSettingsFile(IObservatoryPlugin plugin)
-        //{
-        //    var configDirectory = new FileInfo(ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal).FilePath).Directory;
-        //    return configDirectory.FullName + "\\" + plugin.Name + ".json";
-        //}
-
         private static List<string> LoadPlugins(out List<(IObservatoryWorker plugin, PluginStatus signed)> observatoryWorkers, out List<(IObservatoryNotifier plugin, PluginStatus signed)> observatoryNotifiers)
         {
             observatoryWorkers = new();
@@ -246,7 +240,7 @@ namespace Observatory.PluginManagement
         private static void ExtractPlugins(string pluginFolder)
         {
             var files = Directory.GetFiles(pluginFolder, "*.zip")
-                .Concat(Directory.GetFiles(pluginFolder, "*.eop"));
+                .Concat(Directory.GetFiles(pluginFolder, "*.eop")); // Elite Observatory Plugin
 
             foreach (var file in files)
             {
@@ -263,8 +257,8 @@ namespace Observatory.PluginManagement
                     return null;
                 }
 
-                //Importing Observatory.Framework in the Explorer Lua scripts causes an attempt to reload
-                //the assembly, just hand it back the one we already have.
+                // Importing Observatory.Framework in the Explorer Lua scripts causes an attempt to reload
+                // the assembly, just hand it back the one we already have.
                 if (name.Name.StartsWith("Observatory.Framework") || name.Name == "ObservatoryFramework")
                 {
                     return context.Assemblies.Where(a => a.FullName.Contains("ObservatoryFramework")).First();

--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -12,7 +12,7 @@ namespace Observatory.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
     internal sealed partial class Core : global::System.Configuration.ApplicationSettingsBase {
         
         private static Core defaultInstance = ((Core)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Core())));
@@ -238,7 +238,7 @@ namespace Observatory.Properties {
                 this["NativeNotifyTimeout"] = value;
             }
         }
-
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
@@ -248,6 +248,18 @@ namespace Observatory.Properties {
             }
             set {
                 this["StartMonitor"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string ExportFolder {
+            get {
+                return ((string)(this["ExportFolder"]));
+            }
+            set {
+                this["ExportFolder"] = value;
             }
         }
     }

--- a/ObservatoryCore/Properties/Core.settings
+++ b/ObservatoryCore/Properties/Core.settings
@@ -59,5 +59,8 @@
     <Setting Name="StartMonitor" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ExportFolder" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ObservatoryCore/UI/ViewModels/BasicUIViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/BasicUIViewModel.cs
@@ -15,7 +15,8 @@ namespace Observatory.UI.ViewModels
     public class BasicUIViewModel : ViewModelBase
     {
         private ObservableCollection<object> basicUIGrid;
-        
+
+        public System.Collections.IList SelectedItems { get; set; }        
 
         public ObservableCollection<object> BasicUIGrid
         {

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -82,10 +82,11 @@ namespace Observatory.UI.Views
                         SelectionMode = DataGridSelectionMode.Extended,
                         GridLinesVisibility = DataGridGridLinesVisibility.Vertical,
                         AutoGenerateColumns = true,
-                        IsReadOnly = true,
+                        IsReadOnly = true
                     };
                     dataGrid.AutoGeneratingColumn += ColumnGeneration;
                     dataGrid.DataContextChanged += OnDataContextSet;
+                    dataGrid.SelectionChanged += OnSelectionChanged;
                     uiPanel.Children.Clear();
                     uiPanel.Children.Add(dataGrid);
                     break;
@@ -101,6 +102,12 @@ namespace Observatory.UI.Views
                 default:
                     break;
             }
+        }
+
+        private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ((Observatory.UI.ViewModels.BasicUIViewModel)dataGrid.DataContext).SelectedItems = dataGrid.SelectedItems;
+
         }
 
         private void OnDataContextSet(object sender, EventArgs e)

--- a/ObservatoryCore/UI/Views/CoreView.axaml
+++ b/ObservatoryCore/UI/Views/CoreView.axaml
@@ -73,6 +73,14 @@
           Cursor="Hand">
           Update Available
         </Button>
+		<Button
+		  Name="export"
+		  Margin="10"
+		  FontSize="15"
+		  Command="{Binding ExportGrid}"
+		  Content="Export">
+		  Export
+		</Button>
         <Button 
           Name="ToggleMonitor" 
           Margin="10" 

--- a/ObservatoryCore/UI/Views/NotificationView.axaml.cs
+++ b/ObservatoryCore/UI/Views/NotificationView.axaml.cs
@@ -130,7 +130,10 @@ namespace Observatory.UI.Views
             int corner = Properties.Core.Default.NativeNotifyCorner;
 
             if (screen == -1 || screen > Screens.All.Count)
-                screenBounds = Screens.Primary.Bounds;
+                if (Screens.All.Count == 1)
+                    screenBounds = Screens.All[0].Bounds;
+                else
+                    screenBounds = Screens.Primary.Bounds;
             else
                 screenBounds = Screens.All[screen - 1].Bounds;
 

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -873,6 +873,13 @@
             Version string of Observatory Core.
             </summary>
         </member>
+        <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.GetPluginErrorLogger(Observatory.Framework.Interfaces.IObservatoryPlugin)">
+            <summary>
+            Returns a delegate for logging an error for the calling plugin. A plugin can wrap this method
+            or pass it along to its collaborators.
+            </summary>
+            <param name="plugin">The calling plugin</param>
+        </member>
         <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.ExecuteOnUIThread(System.Action)">
             <summary>
             Perform an action on the current Avalonia UI thread.

--- a/ObservatoryHerald/SpeechRequestManager.cs
+++ b/ObservatoryHerald/SpeechRequestManager.cs
@@ -295,7 +295,7 @@ namespace Observatory.Herald
             stopwatch.Start();
             
             while (!IsFileWritable(cacheIndexFile) && stopwatch.ElapsedMilliseconds < 1000)
-                await new Task(() => System.Threading.Thread.Sleep(100));
+                await Task.Factory.StartNew(() => System.Threading.Thread.Sleep(100));
 
             // 1000ms should be more than enough for a conflicting title or detail to complete,
             // if we're still waiting something else is locking the file, just give up.


### PR DESCRIPTION
Probably should've separate concerns a bit better here.

- Implement basic data export for generic grid views
- Fix possible stack overflow when loading plugin dependencies
- Automatically extract plugins in `.zip` format (or renamed to `.eop`)
- Handle possible file locking from Herlad cache update race condition