### PR TITLE
Export version fixes

### DIFF
--- a/InnoSetup/Elite Observatory.iss
+++ b/InnoSetup/Elite Observatory.iss
@@ -19,6 +19,7 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
+DisableDirPage=false
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 LicenseFile=C:\Users\Xjph\Source\Repos\MIT.txt
@@ -32,6 +33,7 @@ Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 ArchitecturesInstallIn64BitMode=x64
+ChangesAssociations=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -76,6 +78,13 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Registry]
+Root: HKA; Subkey: "Software\Classes\.eop\OpenWithProgids"; ValueType: string; ValueName: "ObservatoryPlugin.eop"; ValueData: ""; Flags: uninsdeletevalue
+Root: HKA; Subkey: "Software\Classes\ObservatoryPlugin.eop"; ValueType: string; ValueName: ""; ValueData: "Elite Observatory Plugin"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\ObservatoryPlugin.eop\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{app}\{#MyAppExeName},0"
+Root: HKA; Subkey: "Software\Classes\ObservatoryPlugin.eop\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\{#MyAppExeName}"" ""%1"""
+Root: HKA; Subkey: "Software\Classes\Applications\{#MyAppExeName}\SupportedTypes"; ValueType: string; ValueName: ".eop"; ValueData: ""
 
 [Code]
 

--- a/ObservatoryCore/NativeNotification/NativePopup.cs
+++ b/ObservatoryCore/NativeNotification/NativePopup.cs
@@ -8,7 +8,6 @@ namespace Observatory.NativeNotification
 {
     public class NativePopup
     {
-        // TODO: This needs to be cleaned up when the app is closed.
         private Dictionary<Guid, NotificationView> notifications;
 
         public NativePopup()

--- a/ObservatoryCore/NativeNotification/NativePopup.cs
+++ b/ObservatoryCore/NativeNotification/NativePopup.cs
@@ -67,5 +67,13 @@ namespace Observatory.NativeNotification
                 });
             }
         }
+
+        public void CloseAll()
+        {
+            foreach (var notification in notifications)
+            {
+                notification.Value?.Close();
+            }
+        }
     }
 }

--- a/ObservatoryCore/ObservatoryCore.cs
+++ b/ObservatoryCore/ObservatoryCore.cs
@@ -9,6 +9,15 @@ namespace Observatory
         [STAThread]
         static void Main(string[] args)
         {
+            if (args.Length > 0 && System.IO.File.Exists(args[0]))
+            {
+                var fileInfo = new System.IO.FileInfo(args[0]);
+                if (fileInfo.Extension == ".eop" || fileInfo.Extension == ".zip")
+                    System.IO.File.Copy(
+                        fileInfo.FullName,
+                         $"{AppDomain.CurrentDomain.BaseDirectory}{System.IO.Path.DirectorySeparatorChar}plugins{System.IO.Path.DirectorySeparatorChar}{fileInfo.Name}");
+            }
+
             string version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString();
             try
             {

--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -170,5 +170,10 @@ namespace Observatory.PluginManagement
                 return folderLocation;
             }
         }
+
+        internal void Shutdown()
+        {
+            NativePopup.CloseAll();
+        }
     }
 }

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -34,6 +34,7 @@ namespace Observatory.PluginManagement
         public readonly List<DataTable> pluginTables;
         public readonly List<(IObservatoryWorker plugin, PluginStatus signed)> workerPlugins;
         public readonly List<(IObservatoryNotifier plugin, PluginStatus signed)> notifyPlugins;
+        private readonly PluginCore core;
         
         private PluginManager()
         {
@@ -48,7 +49,7 @@ namespace Observatory.PluginManagement
             logMonitor.StatusUpdate += pluginHandler.OnStatusUpdate;
             logMonitor.LogMonitorStateChanged += pluginHandler.OnLogMonitorStateChanged;
 
-            var core = new PluginCore();
+            core = new PluginCore();
 
             List<IObservatoryPlugin> errorPlugins = new();
             
@@ -344,6 +345,11 @@ namespace Observatory.PluginManagement
             }
 
             return err;
+        }
+
+        internal void Shutdown()
+        {
+            core.Shutdown();
         }
 
         private static void LoadPlaceholderPlugin(string dllPath, PluginStatus pluginStatus, List<(IObservatoryNotifier plugin, PluginStatus signed)> notifiers)

--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -262,5 +262,17 @@ namespace Observatory.Properties {
                 this["ExportFolder"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool StartReadAll {
+            get {
+                return ((bool)(this["StartReadAll"]));
+            }
+            set {
+                this["StartReadAll"] = value;
+            }
+        }
     }
 }

--- a/ObservatoryCore/Properties/Core.settings
+++ b/ObservatoryCore/Properties/Core.settings
@@ -62,5 +62,8 @@
     <Setting Name="ExportFolder" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="StartReadAll" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ObservatoryCore/UI/MainApplication.axaml.cs
+++ b/ObservatoryCore/UI/MainApplication.axaml.cs
@@ -21,6 +21,11 @@ namespace Observatory.UI
                 {
                     DataContext = new MainWindowViewModel(pluginManager)
                 };
+
+                desktop.MainWindow.Closing += (o, e) =>
+                {
+                    pluginManager.Shutdown();
+                };
             }
 
             base.OnFrameworkInitializationCompleted();

--- a/ObservatoryCore/UI/Models/NotificationModel.cs
+++ b/ObservatoryCore/UI/Models/NotificationModel.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Observatory.UI.Models
+﻿namespace Observatory.UI.Models
 {
     public class NotificationModel
     {

--- a/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
@@ -58,9 +58,10 @@ namespace Observatory.UI.ViewModels
             tabs.Add(new CoreModel() { Name = "Core", UI = new BasicUIViewModel(new ObservableCollection<object>()) { UIType = Framework.PluginUI.UIType.Core } });
 
             if (Properties.Core.Default.StartMonitor)
-            {
                 ToggleMonitor();
-            }
+            
+            if (Properties.Core.Default.StartReadAll)
+                ReadAll();
 
         }
 

--- a/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
@@ -213,6 +213,29 @@ namespace Observatory.UI.ViewModels
             }
         }
 
+        public void ClearGrid()
+        {
+            foreach (var tab in tabs.Where(t => t.Name != "Core"))
+            {
+                var ui = (BasicUIViewModel)tab.UI;
+
+                var rowTemplate = ui.BasicUIGrid.First();
+
+                foreach (var property in rowTemplate.GetType().GetProperties())
+                {
+                    property.SetValue(rowTemplate, string.Empty);
+                }
+
+                ui.BasicUIGrid.Clear();
+                ui.BasicUIGrid.Add(rowTemplate);
+
+                // For some reason UIType's change event will properly
+                // redraw the grid, not BasicUIGris's.
+                ui.RaisePropertyChanged(nameof(ui.UIType));
+               
+            }
+        }
+
         public string ToggleButtonText
         {
             get => toggleButtonText;

--- a/ObservatoryCore/UI/ViewModels/NotificationViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/NotificationViewModel.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Observatory.Framework;
+﻿using Observatory.Framework;
 
 namespace Observatory.UI.ViewModels
 {

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -27,6 +27,11 @@ namespace Observatory.UI.Views
         {
             InitializeComponent();
             nativePopup = new();
+
+            this.DetachedFromVisualTree += (o, e) =>
+            {
+                nativePopup.CloseAll();
+            };
         }
 
         private void InitializeComponent()

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -671,7 +671,7 @@ namespace Observatory.UI.Views
 
             #endregion
 
-            #region Monitor On Launch
+            #region Actions On Launch
 
             TextBlock startMonitorLabel = new() { Text = "Start monitor on Observatory launch" };
             CheckBox startMonitorCheckbox = new() { IsChecked = Properties.Core.Default.StartMonitor, Content = startMonitorLabel };
@@ -685,6 +685,21 @@ namespace Observatory.UI.Views
             startMonitorCheckbox.Unchecked += (object sender, RoutedEventArgs e) =>
             {
                 Properties.Core.Default.StartMonitor = false;
+                Properties.Core.Default.Save();
+            };
+
+            TextBlock startReadAllLabel = new() { Text = "Read All on Observatory launch" };
+            CheckBox startReadAllCheckbox = new() { IsChecked = Properties.Core.Default.StartReadAll, Content = startReadAllLabel };
+
+            startReadAllCheckbox.Checked += (object sender, RoutedEventArgs e) =>
+            {
+                Properties.Core.Default.StartReadAll = true;
+                Properties.Core.Default.Save();
+            };
+
+            startReadAllCheckbox.Unchecked += (object sender, RoutedEventArgs e) =>
+            {
+                Properties.Core.Default.StartReadAll = false;
                 Properties.Core.Default.Save();
             };
 
@@ -758,6 +773,7 @@ namespace Observatory.UI.Views
 
             gridManager.AddSetting(primeSystemContexCheckbox);
             gridManager.AddSetting(startMonitorCheckbox);
+            gridManager.AddSetting(startReadAllCheckbox);
             gridManager.AddSettingWithLabel(journalPathLabel, journalPath);
             gridManager.AddSetting(journalBrowse);
 

--- a/ObservatoryCore/UI/Views/CoreView.axaml
+++ b/ObservatoryCore/UI/Views/CoreView.axaml
@@ -81,6 +81,14 @@
 		  Content="Export">
 		  Export
 		</Button>
+		<Button
+		  Name="clear"
+		  Margin="10"
+		  FontSize="15"
+		  Command="{Binding ClearGrid}"
+		  Content="Clear">
+		  Clear
+		</Button>
         <Button 
           Name="ToggleMonitor" 
           Margin="10" 

--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -141,11 +141,9 @@ namespace Observatory.Explorer
                 results.Add("Nested Moon");
             }
 
-            if (settings.FastRotation && scan.RotationPeriod != 0 && !scan.TidalLock && Math.Abs(scan.RotationPeriod) < 28800 && !isRing)
+            if (settings.FastRotation && scan.RotationPeriod != 0 && !scan.TidalLock && Math.Abs(scan.RotationPeriod) < 28800 && !isRing && string.IsNullOrEmpty(scan.StarType))
             {
-                var spinningRemnants = new List<string> { "H", "N" };
-                if (!spinningRemnants.Contains(scan.StarType))
-                    results.Add("Non-locked Body with Fast Rotation", $"Period: {scan.RotationPeriod/3600:N1} hours");
+                results.Add("Non-locked Body with Fast Rotation", $"Period: {scan.RotationPeriod/3600:N1} hours");
             }
 
             if (settings.FastOrbit && scan.OrbitalPeriod != 0 && Math.Abs(scan.OrbitalPeriod) < 28800 && !isRing)

--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -145,7 +145,9 @@ namespace Observatory.Explorer
 
             if (settings.FastRotation && scan.RotationPeriod != 0 && !scan.TidalLock && Math.Abs(scan.RotationPeriod) < 28800 && !isRing)
             {
-                results.Add("Non-locked Body with Fast Rotation", $"Period: {scan.RotationPeriod/3600:N1} hours");
+                var spinningRemnants = new List<string> { "H", "N" };
+                if (!spinningRemnants.Contains(scan.StarType))
+                    results.Add("Non-locked Body with Fast Rotation", $"Period: {scan.RotationPeriod/3600:N1} hours");
             }
 
             if (settings.FastOrbit && scan.OrbitalPeriod != 0 && Math.Abs(scan.OrbitalPeriod) < 28800 && !isRing)

--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -57,15 +57,17 @@ namespace Observatory.Explorer
 
                 if (HighValueNonTerraformablePlanetClasses.Contains(scan.PlanetClass) || scan.TerraformState?.Length > 0)
                 {
-                    var info = new System.Text.StringBuilder(" ");
-                    if (scan.TerraformState?.Length > 0)
-                        info.Append("(TF)");
+                    var info = new System.Text.StringBuilder();
+                                        
                     if (!scan.WasDiscovered)
-                        info.Append("(FD)");
-                    if (!scan.WasMapped)
-                        info.Append("(FM)");
+                        info.Append("Undiscovered ");
+                    else if (!scan.WasMapped)
+                        info.Append("Unmapped ");
 
-                    results.Add("High-Value Body", $"{scan.DistanceFromArrivalLS:0}Ls, {scan.PlanetClass}{(info.Length > 1 ? info.ToString(): string.Empty)}");
+                    if (scan.TerraformState?.Length > 0)
+                        info.Append("Terraformable ");
+
+                    results.Add("High-Value Body", $"{(info.Length > 1 ? info.ToString() : string.Empty)}{textInfo.ToTitleCase(scan.PlanetClass)}, {scan.DistanceFromArrivalLS:N0}Ls");
                 }
             }
             #endregion

--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -9,18 +9,6 @@ namespace Observatory.Explorer
 {
     internal static class DefaultCriteria
     {
-        private static IList<string> HighValueNonTerraformablePlanetClasses = new string[] {
-            "Earthlike body",
-            "Ammonia world",
-            "Water world",
-        };
-
-        private static IList<string> HighValueTerraformablePlanetClasses = new string[] {
-            "Water world",
-            "High metal content body",
-            "Rocky body",
-        };
-
         public static List<(string Description, string Detail, bool SystemWide)> CheckInterest(Scan scan, Dictionary<ulong, Dictionary<int, Scan>> scanHistory, Dictionary<ulong, Dictionary<int, FSSBodySignals>> signalHistory, ExplorerSettings settings)
         {
             List<(string, string, bool)> results = new();
@@ -61,13 +49,23 @@ namespace Observatory.Explorer
             #region Value Checks
             if (settings.HighValueMappable)
             {
-                if (HighValueTerraformablePlanetClasses.Contains(scan.PlanetClass) && scan.TerraformState?.Length > 0)
+                IList<string> HighValueNonTerraformablePlanetClasses = new string[] {
+                    "Earthlike body",
+                    "Ammonia world",
+                    "Water world",
+                };
+
+                if (HighValueNonTerraformablePlanetClasses.Contains(scan.PlanetClass) || scan.TerraformState?.Length > 0)
                 {
-                    results.Add("High-Value Mapping", $"{scan.DistanceFromArrivalLS:0}Ls, {scan.PlanetClass} (TF)");
-                }
-                if (HighValueNonTerraformablePlanetClasses.Contains(scan.PlanetClass) && scan.TerraformState?.Length == 0)
-                {
-                    results.Add("High-Value Mapping", $"{scan.DistanceFromArrivalLS:0}Ls, {scan.PlanetClass}");
+                    var info = new System.Text.StringBuilder(" ");
+                    if (scan.TerraformState?.Length > 0)
+                        info.Append("(TF)");
+                    if (!scan.WasDiscovered)
+                        info.Append("(FD)");
+                    if (!scan.WasMapped)
+                        info.Append("(FM)");
+
+                    results.Add("High-Value Body", $"{scan.DistanceFromArrivalLS:0}Ls, {scan.PlanetClass}{(info.Length > 1 ? info.ToString(): string.Empty)}");
                 }
             }
             #endregion

--- a/ObservatoryExplorer/Explorer.cs
+++ b/ObservatoryExplorer/Explorer.cs
@@ -224,7 +224,7 @@ namespace Observatory.Explorer
                         spokenAffix =
                             "<say-as interpret-as=\"spell-out\">" + bodyAffix[..ringIndex]
                             + "</say-as><break strength=\"weak\"/>" + SplitOrdinalForSsml(bodyAffix.Substring(ringIndex, 1))
-                            + bodyAffix.Substring(ringIndex + 1, bodyAffix.Length - (ringIndex + 1));
+                            + bodyAffix[(ringIndex + 1)..];
                     }
                     else
                     {
@@ -237,10 +237,12 @@ namespace Observatory.Explorer
                     spokenAffix = string.Empty;
                 }
 
+                string ssmlContent = System.Security.SecurityElement.Escape(bodyLabel + " " + spokenAffix);
+                
                 NotificationArgs args = new()
                 {
                     Title = bodyLabel + bodyAffix,
-                    TitleSsml = $"<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\"><voice name=\"\">{bodyLabel} {spokenAffix}</voice></speak>",
+                    TitleSsml = $"<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\"><voice name=\"\">{ssmlContent}</voice></speak>",
                     Detail = notificationDetail.ToString()
                 };
 

--- a/ObservatoryExplorer/Explorer.cs
+++ b/ObservatoryExplorer/Explorer.cs
@@ -212,7 +212,7 @@ namespace Observatory.Explorer
                     bodyAffix = string.Empty;
                 }
 
-                string bodyLabel = scanEvent.PlanetClass == "Barycentre" ? "Barycentre" : "Body";
+                string bodyLabel = System.Security.SecurityElement.Escape(scanEvent.PlanetClass == "Barycentre" ? "Barycentre" : "Body");
 
                 string spokenAffix;
 
@@ -237,12 +237,10 @@ namespace Observatory.Explorer
                     spokenAffix = string.Empty;
                 }
 
-                string ssmlContent = System.Security.SecurityElement.Escape(bodyLabel + " " + spokenAffix);
-                
                 NotificationArgs args = new()
                 {
                     Title = bodyLabel + bodyAffix,
-                    TitleSsml = $"<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\"><voice name=\"\">{ssmlContent}</voice></speak>",
+                    TitleSsml = $"<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\"><voice name=\"\">{bodyLabel} {spokenAffix}</voice></speak>",
                     Detail = notificationDetail.ToString()
                 };
 

--- a/ObservatoryExplorer/Explorer.cs
+++ b/ObservatoryExplorer/Explorer.cs
@@ -222,13 +222,13 @@ namespace Observatory.Explorer
                     {
                         int ringIndex = bodyAffix.Length - 6;
                         spokenAffix =
-                            "<say-as interpret-as=\"spell-out\">" + bodyAffix.Substring(0, ringIndex) +
-                            "</say-as><break strength=\"weak\"/><say-as interpret-as=\"spell-out\">" +
-                            bodyAffix.Substring(ringIndex, 1) + "</say-as>" + bodyAffix.Substring(ringIndex + 1, bodyAffix.Length - (ringIndex + 1));
+                            "<say-as interpret-as=\"spell-out\">" + bodyAffix[..ringIndex]
+                            + "</say-as><break strength=\"weak\"/>" + SplitOrdinalForSsml(bodyAffix.Substring(ringIndex, 1))
+                            + bodyAffix.Substring(ringIndex + 1, bodyAffix.Length - (ringIndex + 1));
                     }
                     else
                     {
-                        spokenAffix = "<say-as interpret-as=\"spell-out\">" + bodyAffix + "</say-as>";
+                        spokenAffix = SplitOrdinalForSsml(bodyAffix);
                     }
                 }
                 else
@@ -248,5 +248,18 @@ namespace Observatory.Explorer
             }
         }
 
+        private static string SplitOrdinalForSsml(string ordinalString)
+        {
+            var ordinalSegments = ordinalString.Split(' ');
+            StringBuilder affix = new();
+            foreach (var ordinalSegment in ordinalSegments)
+            {
+                if (ordinalSegment.All(Char.IsDigit))
+                    affix.Append(" " + ordinalSegment);
+                else
+                    affix.Append("<say-as interpret-as=\"spell-out\">" + ordinalSegment + "</say-as>");
+            }
+            return affix.ToString();
+        }
     }
 }

--- a/ObservatoryExplorer/ExplorerSettings.cs
+++ b/ObservatoryExplorer/ExplorerSettings.cs
@@ -80,7 +80,7 @@ namespace Observatory.Explorer
         [SettingDisplayName("All Surface Mats In System")]
         public bool GoldSystem { get; set; }
 
-        [SettingDisplayName("High-Value Mapping")]
+        [SettingDisplayName("High-Value Body")]
         public bool HighValueMappable { get; set; }
 
         [SettingDisplayName("Enable Custom Criteria")]

--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -58,6 +58,18 @@ namespace Observatory.Framework
         /// Specifies the desired renderings of the notification.
         /// </summary>
         public NotificationRendering Rendering = NotificationRendering.All;
+        /// <summary>
+        /// Specifies if some part of the notification should be suppressed. (Currently only respected by Herald.)
+        /// </summary>
+        public NotificationSuppression Suppression = NotificationSuppression.None;
+    }
+
+    [Flags]
+    public enum NotificationSuppression
+    {
+        None = 0,
+        Title = 1,
+        Detail = 2,
     }
 
     [Flags]

--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -55,41 +55,81 @@ namespace Observatory.Framework
         /// </summary>
         public double YPos = -1.0;
         /// <summary>
-        /// Specifies the desired renderings of the notification.
+        /// Specifies the desired renderings of the notification. Defaults to <see cref="NotificationRendering.All"/>.
         /// </summary>
         public NotificationRendering Rendering = NotificationRendering.All;
         /// <summary>
-        /// Specifies if some part of the notification should be suppressed. (Currently only respected by Herald.)
+        /// Specifies if some part of the notification should be suppressed. Not supported by all notifiers. Defaults to <see cref="NotificationSuppression.None"/>.
         /// </summary>
         public NotificationSuppression Suppression = NotificationSuppression.None;
     }
 
+    /// <summary>
+    /// Defines constants for suppression of title or detail announcement in a notification.
+    /// </summary>
     [Flags]
     public enum NotificationSuppression
     {
+        /// <summary>
+        /// No suppression.
+        /// </summary>
         None = 0,
+        /// <summary>
+        /// Suppress title.
+        /// </summary>
         Title = 1,
+        /// <summary>
+        /// Suppress detail.
+        /// </summary>
         Detail = 2,
     }
 
+    /// <summary>
+    /// Defines constants for controlling notification routing to plugins or native notification handlers.
+    /// </summary>
     [Flags]
     public enum NotificationRendering
     {
-        // These need to be multiples of 2 as they're used via masking.
+        /// <summary>
+        /// Send notification to native visual popup notificaiton handler.
+        /// </summary>
         NativeVisual = 1,
+        /// <summary>
+        /// Send notification to native speech notification handler.
+        /// </summary>
         NativeVocal = 2,
+        /// <summary>
+        /// Send notification to all installed notifier plugins.
+        /// </summary>
         PluginNotifier = 4,
+        /// <summary>
+        /// Send notification to all available handlers.
+        /// </summary>
         All = (NativeVisual | NativeVocal | PluginNotifier)
     }
 
+    /// <summary>
+    /// Flags indicating current state of journal monitoring.
+    /// </summary>
     [Flags]
     public enum LogMonitorState : uint
     {
-        // These need to be multiples of 2 as they're used via masking.
-        Idle = 0, // Monitoring is stopped
-        Realtime = 1, // Real-time monitoring is active
-        Batch = 2, // Performing a batch read of history
-        PreRead = 4 // Currently pre-reading current system context (a batch read)
+        /// <summary>
+        /// Monitoring is stopped.
+        /// </summary>
+        Idle = 0,
+        /// <summary>
+        /// Real-time monitoring is active.
+        /// </summary>
+        Realtime = 1,
+        /// <summary>
+        /// Batch read of historical journals is in progress.
+        /// </summary>
+        Batch = 2,
+        /// <summary>
+        /// Batch read of recent journals is in progress to establish current player state.
+        /// </summary>
+        PreRead = 4
     }
 
     /// <summary>

--- a/ObservatoryFramework/Files/Converters/MutableStringDoubleConverter.cs
+++ b/ObservatoryFramework/Files/Converters/MutableStringDoubleConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Observatory.Framework.Files.Converters
+{
+    class MutableStringDoubleConverter : JsonConverter<object>
+    {
+        public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+                return reader.GetString();
+            else
+                return reader.GetDouble();
+        }
+
+        public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ObservatoryFramework/Files/Journal/Other/CrewLaunchFighter.cs
+++ b/ObservatoryFramework/Files/Journal/Other/CrewLaunchFighter.cs
@@ -3,6 +3,5 @@
     public class CrewLaunchFighter : CrewMemberJoins
     {
         public ulong ID { get; init; }
-        public bool Telepresence { get; init; }
     }
 }

--- a/ObservatoryFramework/Files/Journal/Other/CrewMemberQuits.cs
+++ b/ObservatoryFramework/Files/Journal/Other/CrewMemberQuits.cs
@@ -1,7 +1,5 @@
 ﻿namespace Observatory.Framework.Files.Journal
 {
     public class CrewMemberQuits : CrewMemberJoins
-    {
-        public bool Telepresence { get; init; }
-    }
+    { }
 }

--- a/ObservatoryFramework/Files/Journal/Other/CrewMemberRoleChange.cs
+++ b/ObservatoryFramework/Files/Journal/Other/CrewMemberRoleChange.cs
@@ -3,6 +3,5 @@
     public class CrewMemberRoleChange : CrewMemberJoins
     {
         public string Role { get; init; }
-        public bool Telepresence { get; init; }
     }
 }

--- a/ObservatoryFramework/Files/Journal/Other/QuitACrew.cs
+++ b/ObservatoryFramework/Files/Journal/Other/QuitACrew.cs
@@ -1,7 +1,5 @@
 ﻿namespace Observatory.Framework.Files.Journal
 {
     public class QuitACrew : JoinACrew
-    {
-        public bool Telepresence { get; init; }
-    }
+    { }
 }

--- a/ObservatoryFramework/Files/ParameterTypes/Modifiers.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/Modifiers.cs
@@ -6,6 +6,7 @@ namespace Observatory.Framework.Files.ParameterTypes
     {
         public string Label { get; init; }
 
+        [JsonConverter(typeof(Converters.MutableStringDoubleConverter))]
         public object Value 
         { 
             get

--- a/ObservatoryFramework/Files/ParameterTypes/Modifiers.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/Modifiers.cs
@@ -6,11 +6,31 @@ namespace Observatory.Framework.Files.ParameterTypes
     {
         public string Label { get; init; }
 
-        public double Value { get; init; }
+        public object Value 
+        { 
+            get
+            {
+                if (!string.IsNullOrEmpty(ValueString))
+                    return ValueString;
+                else
+                    return ValueNumeric;
+            }
+
+            init
+            {
+                if (value.GetType() == typeof(string))
+                    ValueString = value.ToString();
+                else
+                    ValueNumeric = (double)value;
+            }
+        }
 
         public double OriginalValue { get; init; }
 
         [JsonConverter(typeof(Converters.IntBoolConverter))]
         public bool LessIsGood { get; init; }
+
+        private double ValueNumeric;
+        private string ValueString;
     }
 }

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -135,7 +135,82 @@
         </member>
         <member name="F:Observatory.Framework.NotificationArgs.Rendering">
             <summary>
-            Specifies the desired renderings of the notification.
+            Specifies the desired renderings of the notification. Defaults to <see cref="F:Observatory.Framework.NotificationRendering.All"/>.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationArgs.Suppression">
+            <summary>
+            Specifies if some part of the notification should be suppressed. Not supported by all notifiers. Defaults to <see cref="F:Observatory.Framework.NotificationSuppression.None"/>.
+            </summary>
+        </member>
+        <member name="T:Observatory.Framework.NotificationSuppression">
+            <summary>
+            Defines constants for suppression of title or detail announcement in a notification.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationSuppression.None">
+            <summary>
+            No suppression.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationSuppression.Title">
+            <summary>
+            Suppress title.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationSuppression.Detail">
+            <summary>
+            Suppress detail.
+            </summary>
+        </member>
+        <member name="T:Observatory.Framework.NotificationRendering">
+            <summary>
+            Defines constants for controlling notification routing to plugins or native notification handlers.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationRendering.NativeVisual">
+            <summary>
+            Send notification to native visual popup notificaiton handler.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationRendering.NativeVocal">
+            <summary>
+            Send notification to native speech notification handler.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationRendering.PluginNotifier">
+            <summary>
+            Send notification to all installed notifier plugins.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationRendering.All">
+            <summary>
+            Send notification to all available handlers.
+            </summary>
+        </member>
+        <member name="T:Observatory.Framework.LogMonitorState">
+            <summary>
+            Flags indicating current state of journal monitoring.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.LogMonitorState.Idle">
+            <summary>
+            Monitoring is stopped.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.LogMonitorState.Realtime">
+            <summary>
+            Real-time monitoring is active.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.LogMonitorState.Batch">
+            <summary>
+            Batch read of historical journals is in progress.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.LogMonitorState.PreRead">
+            <summary>
+            Batch read of recent journals is in progress to establish current player state.
             </summary>
         </member>
         <member name="T:Observatory.Framework.LogMonitorStateChangedEventArgs">

--- a/ObservatoryHerald/HeraldQueue.cs
+++ b/ObservatoryHerald/HeraldQueue.cs
@@ -132,6 +132,7 @@ namespace Observatory.Herald
                     Thread.Sleep(50);
 
             }
+            speechManager.CommitCache();
         }
     }
 }

--- a/ObservatoryHerald/HeraldQueue.cs
+++ b/ObservatoryHerald/HeraldQueue.cs
@@ -43,7 +43,8 @@ namespace Observatory.Herald
             // to make perceived volume more in line with value set.
             this.volume = ((byte)System.Math.Floor(System.Math.Pow(volume / 100.0, 2.0) * 100));
 
-            notifications.Enqueue(notification);
+            if (!notifications.Where(n => n.Title.Trim().ToLower() == notification.Title.Trim().ToLower()).Any())
+                notifications.Enqueue(notification);
 
             if (!processing)
             {

--- a/ObservatoryHerald/HeraldQueue.cs
+++ b/ObservatoryHerald/HeraldQueue.cs
@@ -131,6 +131,10 @@ namespace Observatory.Herald
                 while (audioPlayer.Playing)
                     Thread.Sleep(50);
 
+                // Explicit stop to ensure device is ready for next file.
+                // ...hopefully.
+                audioPlayer.Stop(true).Wait();
+
             }
             speechManager.CommitCache();
         }

--- a/ObservatoryHerald/HeraldQueue.cs
+++ b/ObservatoryHerald/HeraldQueue.cs
@@ -106,7 +106,7 @@ namespace Observatory.Herald
 
         private async Task<string> RetrieveAudioToFile(string text)
         {
-            return await RetrieveAudioSsmlToFile($"<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\"><voice name=\"\">{text}</voice></speak>");
+            return await RetrieveAudioSsmlToFile($"<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\"><voice name=\"\">{System.Security.SecurityElement.Escape(text)}</voice></speak>");
         }
 
         private async Task<string> RetrieveAudioSsmlToFile(string ssml)

--- a/ObservatoryHerald/NetCoreAudio/Interfaces/IPlayer.cs
+++ b/ObservatoryHerald/NetCoreAudio/Interfaces/IPlayer.cs
@@ -13,7 +13,7 @@ namespace NetCoreAudio.Interfaces
         Task Play(string fileName);
         Task Pause();
         Task Resume();
-        Task Stop();
+        Task Stop(bool force);
         Task SetVolume(byte percent);
     }
 }

--- a/ObservatoryHerald/NetCoreAudio/Player.cs
+++ b/ObservatoryHerald/NetCoreAudio/Player.cs
@@ -71,9 +71,9 @@ namespace NetCoreAudio
         /// Stops any current playback and clears the buffer. Sets Playing and Paused flags to false.
         /// </summary>
         /// <returns></returns>
-        public async Task Stop()
+        public async Task Stop(bool force = false)
         {
-            await _internalPlayer.Stop();
+            await _internalPlayer.Stop(force);
         }
 
         private void OnPlaybackFinished(object sender, EventArgs e)

--- a/ObservatoryHerald/NetCoreAudio/Players/UnixPlayerBase.cs
+++ b/ObservatoryHerald/NetCoreAudio/Players/UnixPlayerBase.cs
@@ -56,7 +56,7 @@ namespace NetCoreAudio.Players
             return Task.CompletedTask;
         }
 
-        public Task Stop()
+        public Task Stop(bool force = false)
         {
             if (_process != null)
             {

--- a/ObservatoryHerald/NetCoreAudio/Players/WindowsPlayer.cs
+++ b/ObservatoryHerald/NetCoreAudio/Players/WindowsPlayer.cs
@@ -83,11 +83,8 @@ namespace NetCoreAudio.Players
                 ExecuteMciCommand($"Stop {_fileName}");
 				Playing = false;
                 Paused = false;
-                if (!force)
-                {
-                    _playbackTimer.Stop();
-                    _playStopwatch.Stop();
-                }
+                _playbackTimer?.Stop();
+                _playStopwatch?.Stop();
             }
             return Task.CompletedTask;
         }

--- a/ObservatoryHerald/NetCoreAudio/Players/WindowsPlayer.cs
+++ b/ObservatoryHerald/NetCoreAudio/Players/WindowsPlayer.cs
@@ -76,15 +76,18 @@ namespace NetCoreAudio.Players
             return Task.CompletedTask;
         }
 
-        public Task Stop()
+        public Task Stop(bool force = false)
         {
-            if (Playing)
+            if (Playing || force)
             {
                 ExecuteMciCommand($"Stop {_fileName}");
 				Playing = false;
                 Paused = false;
-                _playbackTimer.Stop();
-                _playStopwatch.Stop();
+                if (!force)
+                {
+                    _playbackTimer.Stop();
+                    _playStopwatch.Stop();
+                }
             }
             return Task.CompletedTask;
         }

--- a/ObservatoryHerald/ObservatoryAPI.Designer.cs
+++ b/ObservatoryHerald/ObservatoryAPI.Designer.cs
@@ -19,7 +19,7 @@ namespace Observatory.Herald {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ObservatoryAPI {

--- a/ObservatoryHerald/SpeechRequestManager.cs
+++ b/ObservatoryHerald/SpeechRequestManager.cs
@@ -127,8 +127,6 @@ namespace Observatory.Herald
                 voiceNode.InnerXml = expressAsNode.OuterXml;
             }
 
-            
-
             return ssmlDoc.OuterXml;
         }
 

--- a/ObservatoryHerald/SpeechRequestManager.cs
+++ b/ObservatoryHerald/SpeechRequestManager.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Xml;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using System.Collections.Concurrent;
 
 namespace Observatory.Herald
 {
@@ -19,7 +20,8 @@ namespace Observatory.Herald
         private string ApiEndpoint;
         private DirectoryInfo cacheLocation;
         private int cacheSize;
-        private Action<Exception, String> ErrorLogger;
+        private Action<Exception, string> ErrorLogger;
+        private ConcurrentDictionary<string, CacheData> cacheIndex;
 
         internal SpeechRequestManager(
             HeraldSettings settings, HttpClient httpClient, string cacheFolder, Action<Exception, String> errorLogger)
@@ -29,6 +31,7 @@ namespace Observatory.Herald
             this.httpClient = httpClient;
             cacheSize = Math.Max(settings.CacheSize, 1);
             cacheLocation = new DirectoryInfo(cacheFolder);
+            ReadCache();
             ErrorLogger = errorLogger;
 
             if (!Directory.Exists(cacheLocation.FullName))
@@ -229,10 +232,8 @@ namespace Observatory.Herald
             return demonym;
         }
 
-        private async void UpdateAndPruneCache(FileInfo currentFile)
+        private void ReadCache()
         {
-            Dictionary<string, CacheData> cacheIndex;
-
             string cacheIndexFile = cacheLocation + "CacheIndex.json";
 
             if (File.Exists(cacheIndexFile))
@@ -240,7 +241,7 @@ namespace Observatory.Herald
                 var indexFileContent = File.ReadAllText(cacheIndexFile);
                 try
                 {
-                    cacheIndex = JsonSerializer.Deserialize<Dictionary<string, CacheData>>(indexFileContent);
+                    cacheIndex = JsonSerializer.Deserialize<ConcurrentDictionary<string, CacheData>>(indexFileContent);
                 }
                 catch (Exception ex)
                 {
@@ -258,9 +259,13 @@ namespace Observatory.Herald
             var cacheFiles = cacheLocation.GetFiles("*.mp3");
             foreach (var file in cacheFiles.Where(file => !cacheIndex.ContainsKey(file.Name)))
             {
-                cacheIndex.Add(file.Name, new(file.CreationTime, 0));
+                cacheIndex.TryAdd(file.Name, new(file.CreationTime, 0));
             };
+        }
 
+        private void UpdateAndPruneCache(FileInfo currentFile)
+        {
+            var cacheFiles = cacheLocation.GetFiles("*.mp3");
             if (cacheIndex.ContainsKey(currentFile.Name))
             {
                 cacheIndex[currentFile.Name] = new(
@@ -270,13 +275,15 @@ namespace Observatory.Herald
             }
             else
             {
-                cacheIndex.Add(currentFile.Name, new(DateTime.UtcNow, 1));
+                cacheIndex.TryAdd(currentFile.Name, new(DateTime.UtcNow, 1));
             }
 
-            var currentCacheSize = cacheFiles.Sum(f => f.Length);
-            while (currentCacheSize > cacheSize * 1024 * 1024)
-            {
+            var indexedCacheSize = cacheFiles
+                .Where(f => cacheIndex.ContainsKey(f.Name))
+                .Sum(f => f.Length);
 
+            while (indexedCacheSize > cacheSize * 1024 * 1024)
+            {
                 var staleFile = (from file in cacheIndex
                                 orderby file.Value.HitCount, file.Value.Created
                                 select file.Key).First();
@@ -284,16 +291,19 @@ namespace Observatory.Herald
                 if (staleFile == currentFile.Name)
                     break;
 
-                currentCacheSize -= new FileInfo(cacheLocation + staleFile).Length;
-                File.Delete(cacheLocation + staleFile);
-                cacheIndex.Remove(staleFile);
+                cacheIndex.TryRemove(staleFile, out _);
             }
+        }
 
-            // Race conditions between title and detail speech make a collision here possible.
-            // Wait for file to become writable, but return control to call site while we wait.
+        internal async void CommitCache()
+        {
+            string cacheIndexFile = cacheLocation + "CacheIndex.json";
+
             System.Diagnostics.Stopwatch stopwatch = new();
             stopwatch.Start();
-            
+
+            // Race condition isn't a concern anymore, but should check this anyway to be safe.
+            // (Maybe someone is poking at the file with notepad?)
             while (!IsFileWritable(cacheIndexFile) && stopwatch.ElapsedMilliseconds < 1000)
                 await Task.Factory.StartNew(() => System.Threading.Thread.Sleep(100));
 
@@ -325,7 +335,7 @@ namespace Observatory.Herald
             }
         }
 
-        public class CacheData
+        private class CacheData
         {
             public CacheData(DateTime Created, int HitCount)
             {

--- a/ObservatoryHerald/SpeechRequestManager.cs
+++ b/ObservatoryHerald/SpeechRequestManager.cs
@@ -106,25 +106,28 @@ namespace Observatory.Herald
             XmlNamespaceManager ssmlNs = new(ssmlDoc.NameTable);
             ssmlNs.AddNamespace("ssml", ssmlNamespace);
             ssmlNs.AddNamespace("mstts", "http://www.w3.org/2001/mstts");
+            ssmlNs.AddNamespace("emo", "http://www.w3.org/2009/10/emotionml");
 
             var voiceNode = ssmlDoc.SelectSingleNode("/ssml:speak/ssml:voice", ssmlNs);
             voiceNode.Attributes.GetNamedItem("name").Value = voiceName;
 
+            if (!string.IsNullOrWhiteSpace(rate))
+            {
+                var prosodyNode = ssmlDoc.CreateElement("ssml", "prosody", ssmlNamespace);
+                prosodyNode.SetAttribute("rate", rate);
+                prosodyNode.InnerXml = voiceNode.InnerXml;
+                voiceNode.InnerXml = prosodyNode.OuterXml;
+            }
+
             if (!string.IsNullOrWhiteSpace(styleName))
             {
-                var expressAsNode = ssmlDoc.CreateElement("express-as", "http://www.w3.org/2001/mstts");
+                var expressAsNode = ssmlDoc.CreateElement("mstts", "express-as", "http://www.w3.org/2001/mstts");
                 expressAsNode.SetAttribute("style", styleName);
                 expressAsNode.InnerXml = voiceNode.InnerXml;
                 voiceNode.InnerXml = expressAsNode.OuterXml;
             }
 
-            if (!string.IsNullOrWhiteSpace(rate))
-            {
-                var prosodyNode = ssmlDoc.CreateElement("prosody", ssmlNamespace);
-                prosodyNode.SetAttribute("rate", rate);
-                prosodyNode.InnerXml = voiceNode.InnerXml;
-                voiceNode.InnerXml = prosodyNode.OuterXml;
-            }
+            
 
             return ssmlDoc.OuterXml;
         }


### PR DESCRIPTION
Features added:

- Handle plugin installation on startup via file argument
- Create file association during install
- Suppress repeated notification titles in a single Herald voice queue
- Add option to real-all on launch

Issues addressed:

- Installer now asks for install location
- Filter fast spinning stellar remnants from "fast rotation" check
- Refactor new "high value" check and change wording
- Complete overhaul of herald cache handling to remove race condition
- SSML re-ordered and namespace handling improved; fixes selected voice styles not working
- _Maybe_ have finally put to bed issue where second voice line doesn't always play
- Fix explorer ssml titles placing numeric ordinals in `spell-out` elements.
