### PR TITLE
Workaround journal bug: Already mapped bodies are not undiscovered

### DIFF
--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -59,15 +59,18 @@ namespace Observatory.Explorer
                 {
                     var info = new System.Text.StringBuilder();
                                         
-                    if (!scan.WasDiscovered)
-                        info.Append("Undiscovered ");
-                    else if (!scan.WasMapped)
-                        info.Append("Unmapped ");
+                    if (!scan.WasMapped)
+                    {
+                        if (!scan.WasDiscovered)
+                            info.Append("Undiscovered ");
+                        else
+                            info.Append("Unmapped ");
+                    }
 
                     if (scan.TerraformState?.Length > 0)
                         info.Append("Terraformable ");
 
-                    results.Add("High-Value Body", $"{(info.Length > 1 ? info.ToString() : string.Empty)}{textInfo.ToTitleCase(scan.PlanetClass)}, {scan.DistanceFromArrivalLS:N0}Ls");
+                    results.Add("High-Value Body", $"{info.ToString()}{textInfo.ToTitleCase(scan.PlanetClass)}, {scan.DistanceFromArrivalLS:N0}Ls");
                 }
             }
             #endregion


### PR DESCRIPTION
Just checking something is not already discovered is not enough. Many valuable bodies in the bubble mis-fire this criteria because the journal reports them as not discovered (because they have no first discoverer because they're well known systems). Checking that they're also not mapped ensures this doesn't happen.

Also simplified rendering of the string info.