### PR TITLE
Fix boolean logic bug that slows ancillary file reading to a crawl

### DIFF
--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -352,7 +352,7 @@ namespace Observatory
             string fileContent = null;
             int retryCount = 0;
             
-            while (fileContent == null || retryCount < 10)
+            while (fileContent == null && retryCount < 10)
             {
                 System.Threading.Thread.Sleep(50);
                 try


### PR DESCRIPTION
Symptoms: App takes a very long time to start up, sluggish response to events because it's reading and processing every ancillary file 10x instead of just once when successful.