### PR TITLE
Disable ShowActivated on notifications to avoid focus stealing

### DIFF
--- a/ObservatoryCore/UI/Views/NotificationView.axaml.cs
+++ b/ObservatoryCore/UI/Views/NotificationView.axaml.cs
@@ -25,9 +25,9 @@ namespace Observatory.UI.Views
             this.guid = guid;
             InitializeComponent();
             SystemDecorations = SystemDecorations.None;
+            ShowActivated = false;
             ShowInTaskbar = false;
             MakeClickThrough(); //Platform specific, currently windows only.
-
 
             this.DataContextChanged += NotificationView_DataContextChanged;
             scale = Properties.Core.Default.NativeNotifyScale / 100.0;


### PR DESCRIPTION
The recently updated avalonia seemed to change behavior in a way that caused notifications to steal focus from the game (often at at inopportune times). Not all users experienced this.