### PR TITLE
Implement Tab separated export format

### DIFF
--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -12,7 +12,7 @@ namespace Observatory.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     internal sealed partial class Core : global::System.Configuration.ApplicationSettingsBase {
         
         private static Core defaultInstance = ((Core)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Core())));
@@ -272,6 +272,18 @@ namespace Observatory.Properties {
             }
             set {
                 this["StartReadAll"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Fixed width")]
+        public string ExportStyle {
+            get {
+                return ((string)(this["ExportStyle"]));
+            }
+            set {
+                this["ExportStyle"] = value;
             }
         }
     }

--- a/ObservatoryCore/Properties/Core.settings
+++ b/ObservatoryCore/Properties/Core.settings
@@ -65,5 +65,8 @@
     <Setting Name="StartReadAll" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ExportStyle" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Fixed width</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
@@ -112,95 +112,67 @@ namespace Observatory.UI.ViewModels
             try
             {
                 var exportFolder = Properties.Core.Default.ExportFolder;
-
                 if (string.IsNullOrEmpty(exportFolder))
                 {
                     exportFolder = System.Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+
+                    OpenFolderDialog openFolderDialog = new()
+                    {
+                        Directory = exportFolder
+                    };
+
+                    var application = (IClassicDesktopStyleApplicationLifetime)Avalonia.Application.Current.ApplicationLifetime;
+
+                    var selectedFolder = await openFolderDialog.ShowAsync(application.MainWindow);
+
+                    if (!string.IsNullOrEmpty(selectedFolder))
+                    {
+                        Properties.Core.Default.ExportFolder = selectedFolder;
+                        Properties.Core.Default.Save();
+                        exportFolder = selectedFolder;
+                    }
                 }
 
-                OpenFolderDialog openFolderDialog = new()
+                var exportStyle = Properties.Core.Default.ExportStyle;
+                if (string.IsNullOrEmpty(exportStyle))
                 {
-                    Directory = exportFolder
-                };
-
-                var application = (IClassicDesktopStyleApplicationLifetime)Avalonia.Application.Current.ApplicationLifetime;
-
-                var selectedFolder = await openFolderDialog.ShowAsync(application.MainWindow);
-
-                if (!string.IsNullOrEmpty(selectedFolder))
-                {
-                    Properties.Core.Default.ExportFolder = selectedFolder;
+                    exportStyle = "Fixed width";
+                    Properties.Core.Default.ExportStyle = exportStyle;
                     Properties.Core.Default.Save();
-                    exportFolder = selectedFolder;
+                }
 
-                    foreach (var tab in tabs.Where(t => t.Name != "Core"))
+                foreach (var tab in tabs.Where(t => t.Name != "Core"))
+                {
+                    var ui = (BasicUIViewModel)tab.UI;
+                    List<object> selectedData;
+                    bool specificallySelected = ui.SelectedItems?.Count > 1;
+
+                    if (specificallySelected)
                     {
-                        var ui = (BasicUIViewModel)tab.UI;
-                        List<object> selectedData;
-                        bool specificallySelected = ui.SelectedItems?.Count > 1;
+                        selectedData = new();
 
-                        if (specificallySelected)
-                        {
-                            selectedData = new();
-
-                            foreach (var item in ui.SelectedItems)
-                                selectedData.Add(item);
-                        }
-                        else
-                        {
-                            selectedData = ui.BasicUIGrid.ToList();
-                        }
-
-                        var columns = selectedData[0].GetType().GetProperties();
-                        Dictionary<string, int> colSize = new();
-                        Dictionary<string, List<string>> colContent = new();
-
-                        foreach (var column in columns)
-                        {
-                            colSize.Add(column.Name, 0);
-                            colContent.Add(column.Name, new());
-                        }
-
-                        foreach (var line in selectedData)
-                        {
-                            var lineType = line.GetType(); // some plugins have different line types, so don't move this out of loop
-                            foreach (var column in colContent)
-                            {
-                                var cellValue = lineType.GetProperty(column.Key)?.GetValue(line)?.ToString() ?? string.Empty;
-                                column.Value.Add(cellValue);
-                                if (colSize[column.Key] < cellValue.Length)
-                                    colSize[column.Key] = cellValue.Length;
-                            }
-                        }
-
-                        System.Text.StringBuilder exportData = new();
-
-
-                        foreach (var colTitle in colContent.Keys)
-                        {
-                            if (colSize[colTitle] < colTitle.Length)
-                                colSize[colTitle] = colTitle.Length;
-
-                            exportData.Append(colTitle.PadRight(colSize[colTitle]) + "  ");
-                        }
-                        exportData.AppendLine();
-
-                        for (int i = 0; i < colContent.First().Value.Count; i++)
-                        {
-                            foreach (var column in colContent)
-                            {
-                                if (column.Value[i].Length > 0 && !char.IsNumber(column.Value[i][0]) && column.Value[i].Count(char.IsLetter) / (float)column.Value[i].Length > 0.25)
-                                    exportData.Append(column.Value[i].PadRight(colSize[column.Key]) + "  ");
-                                else
-                                    exportData.Append(column.Value[i].PadLeft(colSize[column.Key]) + "  ");
-                            }
-                            exportData.AppendLine();
-                        }
-
-                        string exportPath = $"{exportFolder}{System.IO.Path.DirectorySeparatorChar}Observatory Export - {DateTime.UtcNow:yyyyMMdd-HHmmss} - {tab.Name}.txt";
-
-                        System.IO.File.WriteAllText(exportPath, exportData.ToString());
+                        foreach (var item in ui.SelectedItems)
+                            selectedData.Add(item);
                     }
+                    else
+                    {
+                        selectedData = ui.BasicUIGrid.ToList();
+                    }
+
+                    System.Text.StringBuilder exportData;
+                    switch (exportStyle)
+                    {
+                        case "Tab separated":
+                            exportData = ExportTabSeparated(selectedData);
+                            break;
+                        default: // Fixed width.
+                            exportData = ExportFixedWidth(selectedData);
+                            break;
+                    }
+
+                    string exportPath = $"{exportFolder}{System.IO.Path.DirectorySeparatorChar}Observatory Export - {DateTime.UtcNow:yyyyMMdd-HHmmss} - {tab.Name}.txt";
+
+                    System.IO.File.WriteAllText(exportPath, exportData.ToString());
                 }
             }
             catch (Exception e)
@@ -209,6 +181,78 @@ namespace Observatory.UI.ViewModels
                 ErrorReporter.ShowErrorPopup("Error encountered!",
                     new List<(string, string)> { ("An error occurred while exporting; output may be missing or incomplete." + Environment.NewLine +
                     "Please check the error log (found in your Documents folder) for more details and visit our discord to report it.", e.Message) });
+            }
+
+            static System.Text.StringBuilder ExportTabSeparated(List<object> selectedData)
+            {
+                System.Text.StringBuilder exportData = new();
+
+                var columnNames = selectedData[0].GetType().GetProperties().Select(c => c.Name).ToList();
+                exportData.AppendJoin('\t', columnNames).AppendLine();
+
+                var lastColumn = columnNames.Last();
+                foreach (var line in selectedData)
+                {
+                    var lineType = line.GetType(); // some plugins have different line types, so don't move this out of loop
+                    foreach (var columnName in columnNames)
+                    {
+                        var cellValue = lineType.GetProperty(columnName)?.GetValue(line)?.ToString() ?? string.Empty;
+                        exportData.Append(cellValue).Append('\t');
+                    }
+                    exportData.AppendLine();
+                }
+                return exportData;
+            }
+
+            static System.Text.StringBuilder ExportFixedWidth(List<object> selectedData)
+            {
+                Dictionary<string, int> colSize = new();
+                Dictionary<string, List<string>> colContent = new();
+
+                var columns = selectedData[0].GetType().GetProperties();
+                foreach (var column in columns)
+                {
+                    colSize.Add(column.Name, column.Name.Length);
+                    colContent.Add(column.Name, new());
+                }
+
+                foreach (var line in selectedData)
+                {
+                    var lineType = line.GetType(); // some plugins have different line types, so don't move this out of loop
+                    foreach (var column in colContent)
+                    {
+                        var cellValue = lineType.GetProperty(column.Key)?.GetValue(line)?.ToString() ?? string.Empty;
+                        column.Value.Add(cellValue);
+                        if (colSize[column.Key] < cellValue.Length)
+                            colSize[column.Key] = cellValue.Length;
+                    }
+                }
+
+                System.Text.StringBuilder exportData = new();
+
+
+                foreach (var colTitle in colContent.Keys)
+                {
+                    if (colSize[colTitle] < colTitle.Length)
+                        colSize[colTitle] = colTitle.Length;
+
+                    exportData.Append(colTitle.PadRight(colSize[colTitle]) + "  ");
+                }
+                exportData.AppendLine();
+
+                for (int i = 0; i < colContent.First().Value.Count; i++)
+                {
+                    foreach (var column in colContent)
+                    {
+                        if (column.Value[i].Length > 0 && !char.IsNumber(column.Value[i][0]) && column.Value[i].Count(char.IsLetter) / (float)column.Value[i].Length > 0.25)
+                            exportData.Append(column.Value[i].PadRight(colSize[column.Key]) + "  ");
+                        else
+                            exportData.Append(column.Value[i].PadLeft(colSize[column.Key]) + "  ");
+                    }
+                    exportData.AppendLine();
+                }
+
+                return exportData;
             }
         }
 

--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -647,9 +647,112 @@ namespace Observatory.UI.Views
                 voiceExpander.Content = voiceGrid;
 
                 gridManager.AddSetting(voiceExpander);
-
-
             }
+            #endregion
+
+            #region Export options
+
+            Expander exportExpander = new()
+            {
+                Header = "Export Options",
+                DataContext = Properties.Core.Default,
+                Margin = new Thickness(0, 0)
+            };
+
+            Grid exportGrid = new() { Margin = new Thickness(10, 10) };
+            SettingGridManager exportGridManager = new(exportGrid);
+
+            exportGrid.ColumnDefinitions = new()
+            {
+                new ColumnDefinition() { Width = new GridLength(0, GridUnitType.Star) },
+                new ColumnDefinition() { Width = new GridLength(3, GridUnitType.Star) },
+                new ColumnDefinition() { Width = new GridLength(3, GridUnitType.Star) }
+            };
+
+            TextBlock exportStyleLabel = new()
+            {
+                Text = "Export style: ",
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+            };
+            ComboBox exportStyleDropDown = new()
+            {
+                MinWidth = 200
+            };
+
+            exportStyleDropDown.Items = new List<string>() {
+                    "Fixed width",
+                    "Tab separated",
+                };
+
+            if (Properties.Core.Default.ExportStyle.Length > 0)
+            {
+                exportStyleDropDown.SelectedItem = Properties.Core.Default.ExportStyle;
+            }
+
+            exportStyleDropDown.SelectionChanged += (object sender, SelectionChangedEventArgs e) =>
+            {
+                var comboBox = (ComboBox)sender;
+                Properties.Core.Default.ExportStyle = comboBox.SelectedItem.ToString();
+                Properties.Core.Default.Save();
+            };
+
+            TextBlock exportPathLabel = new()
+            {
+                Text = "Export Path: ",
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center
+            };
+
+            TextBox exportPath = new()
+            {
+                Text = Properties.Core.Default.ExportFolder
+            };
+
+            Button exportBrowse = new()
+            {
+                Content = "Browse",
+                Height = 30,
+                Width = 100,
+                HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right,
+                HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Center
+            };
+
+            exportBrowse.Click += (object source, RoutedEventArgs e) =>
+            {
+                OpenFolderDialog openFolderDialog = new()
+                {
+                    Directory = exportPath.Text
+                };
+                var browseTask = openFolderDialog.ShowAsync((Window)((Button)source).GetVisualRoot());
+                browseTask.ContinueWith((task) =>
+                {
+                    string path = task.Result;
+                    if (path != string.Empty)
+                    {
+                        Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => { exportPath.Text = path; });
+                        Properties.Core.Default.ExportFolder = path;
+                        Properties.Core.Default.Save();
+                    }
+                });
+            };
+
+            exportPath.LostFocus += (object sender, RoutedEventArgs e) =>
+            {
+                if (System.IO.Directory.Exists(exportPath.Text))
+                {
+                    Properties.Core.Default.ExportFolder = exportPath.Text;
+                    Properties.Core.Default.Save();
+                }
+            };
+
+            exportGridManager.AddSettingWithLabel(exportStyleLabel, exportStyleDropDown);
+            exportGridManager.AddSettingWithLabel(exportPathLabel, exportPath);
+            exportGridManager.AddSetting(exportBrowse);
+
+            exportExpander.Content = exportGrid;
+
+            gridManager.AddSetting(exportExpander);
             #endregion
 
             #region System Context Priming setting


### PR DESCRIPTION
Tab separated output facilitates much more efficient opening of exported content in a spreadsheet for further data analysis, furthermore, it vastly reduces file size at the cost of human-readability. However, for the spreadsheet junkies among us, this is a welcome option.

To complement this, there is now an "Export Options" expander in the Core settings panel. Here one can select their preferred export style (default remains Fixed width) and now one can pre-select the export folder.

With this change, clicking export *will not* prompt for an export folder if one is already set. It will simply immediately export data.