### PR TITLE
Update notification window position on Show()

### DIFF
--- a/ObservatoryCore/UI/Views/NotificationView.axaml.cs
+++ b/ObservatoryCore/UI/Views/NotificationView.axaml.cs
@@ -71,6 +71,18 @@ namespace Observatory.UI.Views
             }
         }
 
+        public override void Show()
+        {
+            base.Show();
+
+            // Refresh the position when the window is opened (required
+            // on Linux to show the notification in the right position)
+            if (DataContext is NotificationViewModel nvm)
+            {
+                AdjustPosition(nvm.Notification.XPos / 100, nvm.Notification.YPos / 100);
+            }
+        }
+
         private void NotificationView_DataContextChanged(object sender, EventArgs e)
         {
             var notification = ((NotificationViewModel)DataContext).Notification;


### PR DESCRIPTION
There's a small bug on Linux where notification windows are spawned in the middle of the primary screen. This PR addresses this bug by updating the position of the window right after `Show()` is called.