### PR TITLE
Fonts on Linux + cleanup

### DIFF
--- a/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
+++ b/ObservatoryCore/UI/Views/BasicUIView.axaml.cs
@@ -11,10 +11,14 @@ using Avalonia.VisualTree;
 using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing.Text;
 using Avalonia.Media;
 using Avalonia.Controls.ApplicationLifetimes;
 using System.Runtime.InteropServices;
 using System.IO;
+using Observatory.Util;
+using Observatory.X11;
 
 namespace Observatory.UI.Views
 {
@@ -305,7 +309,20 @@ namespace Observatory.UI.Views
                 MinWidth = 200
             };
 
-            notifyFontDropDown.Items = new System.Drawing.Text.InstalledFontCollection().Families.Select(font => font.Name);
+            try
+            {
+                // Attempt to get a list of installed fonts using System.Drawing
+                notifyFontDropDown.Items = new InstalledFontCollection().Families.Select(font => font.Name);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // System.Drawing is not supported on some Linux distributions. Try to get the font list from X11 instead
+                // https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                { 
+                    notifyFontDropDown.Items = FontConfigUtil.GetInstalledFontNames();
+                }
+            }
 
             if (Properties.Core.Default.NativeNotifyFont.Length > 0)
             {

--- a/ObservatoryCore/UI/Views/NotificationView.axaml.cs
+++ b/ObservatoryCore/UI/Views/NotificationView.axaml.cs
@@ -7,6 +7,7 @@ using System;
 using System.Reflection;
 using System.Timers;
 using System.Runtime.InteropServices;
+using Observatory.X11;
 
 namespace Observatory.UI.Views
 {
@@ -226,11 +227,11 @@ namespace Observatory.UI.Views
                 try
                 {
                     // Create a very tiny region
-                    var region = XFixesCreateRegion((IntPtr)display, IntPtr.Zero, 0);
+                    var region = XLib.XFixesCreateRegion((IntPtr)display, IntPtr.Zero, 0);
                     // Set the input shape of the window to our region
-                    XFixesSetWindowShapeRegion((IntPtr)display, (IntPtr)handle, ShapeInput, 0, 0, region);
+                    XLib.XFixesSetWindowShapeRegion((IntPtr)display, (IntPtr)handle, XLib.ShapeInput, 0, 0, region);
                     // Cleanup
-                    XFixesDestroyRegion((IntPtr)display, region);
+                    XLib.XFixesDestroyRegion((IntPtr)display, region);
                 }
                 catch
                 {
@@ -252,16 +253,5 @@ namespace Observatory.UI.Views
         internal const int WS_EX_LAYERED = 0x80000;
         internal const int LWA_ALPHA = 0x2;
         internal const int WS_EX_TRANSPARENT = 0x00000020;
-        
-        [DllImport("libXfixes.so")]
-        static extern IntPtr XFixesCreateRegion(IntPtr dpy, IntPtr rectangles, int nrectangles);
-
-        [DllImport("libXfixes.so")]
-        static extern IntPtr XFixesSetWindowShapeRegion(IntPtr dpy, IntPtr win, int shape_kind, int x_off, int y_off, IntPtr region);
-
-        [DllImport("libXfixes.so")]
-        static extern IntPtr XFixesDestroyRegion(IntPtr dpy, IntPtr region);
-        
-        internal const int ShapeInput = 2;
     }
 }

--- a/ObservatoryCore/Util/FontConfigUtil.cs
+++ b/ObservatoryCore/Util/FontConfigUtil.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics;
+
+namespace Observatory.Util;
+
+public class FontConfigUtil
+{
+    /// <summary>
+    /// Runs 'fc-list' to get a list of installed fonts
+    /// </summary>
+    /// <returns>A list of installed fonts</returns>
+    public static IEnumerable<string> GetInstalledFontNames()
+    {
+        // Launch process
+        var process = new Process();
+        process.StartInfo.FileName = "fc-list";
+        process.StartInfo.CreateNoWindow = true;
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.Start();
+        
+        // Read output
+        using var s = process.StandardOutput;
+        var data = s.ReadToEnd();
+        process.WaitForExit(1000);
+        
+        // Example output:
+        // /usr/share/fonts/gsfonts/URWBookman-DemiItalic.otf: URW Bookman:style=Demi Italic
+        // /usr/share/fonts/noto/NotoSansMono-Light.ttf: Noto Sans Mono,Noto Sans Mono Light:style=Light,Regular
+        // /usr/share/fonts/TTF/DejaVuSerifCondensed.ttf: DejaVu Serif,DejaVu Serif Condensed:style=Condensed,Book
+        // /usr/share/fonts/liberation/LiberationSerif-Italic.ttf: Liberation Serif:style=Italic
+
+        // Parse output and return
+        return data.Split('\n')
+            .Where(i => i.Trim().Length > 0)
+            .Select(i => i.Split(':', 2)[1].Trim().Split(':')[0])
+            .ToArray();
+    }
+}

--- a/ObservatoryCore/X11/XLib.cs
+++ b/ObservatoryCore/X11/XLib.cs
@@ -1,0 +1,20 @@
+using System.Runtime.InteropServices;
+
+namespace Observatory.X11;
+
+public class XLib
+{
+    public const int ShapeInput = 2;
+
+    [DllImport("libXfixes.so")]
+    // XserverRegion XFixesCreateRegion (Display *dpy, XRectangle *rectangles, int nrectangles)
+    public static extern IntPtr XFixesCreateRegion(IntPtr dpy, IntPtr rectangles, int nrectangles);
+
+    [DllImport("libXfixes.so")]
+    // void XFixesSetWindowShapeRegion (Display *dpy, Window win, int shape_kind, int x_off, int y_off, XserverRegion region)
+    public static extern IntPtr XFixesSetWindowShapeRegion(IntPtr dpy, IntPtr win, int shape_kind, int x_off, int y_off, IntPtr region);
+
+    [DllImport("libXfixes.so")]
+    // void XFixesDestroyRegion (Display *dpy, XserverRegion region)
+    public static extern IntPtr XFixesDestroyRegion(IntPtr dpy, IntPtr region);
+}


### PR DESCRIPTION
`System.Drawing` is used to get a list of installed fonts which is [unsupported on Linux](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only) (but only on certain distributions apparently because it works on my Linux machine, see cerus/observatorycore-linux#1)

This PR addresses the issue by falling back to running [`fc-list`](https://www.unix.com/man-page/linux/1/fc-list/) if `System.Drawing` is unavailable. I've tried to use X11 functions to get a list of installed fonts, but that wasn't successful. I moved all of the X11 stuff into another class during my attempt.

Let me know if anything needs changing!