### PR TITLE
2 Bug Fixes

### DIFF
--- a/ObservatoryCore/LogMonitor.cs
+++ b/ObservatoryCore/LogMonitor.cs
@@ -420,12 +420,19 @@ namespace Observatory
         private List<string> ReadAllLines(string path)
         {
             var lines = new List<string>();
-            using (StreamReader file = new StreamReader(File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            try
             {
-                while (!file.EndOfStream)
+                using (StreamReader file = new StreamReader(File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
                 {
-                    lines.Add(file.ReadLine());
+                    while (!file.EndOfStream)
+                    {
+                        lines.Add(file.ReadLine());
+                    }
                 }
+            }
+            catch (IOException ioEx)
+            {
+                ReportErrors(new List<(Exception, string, string)>() { (ioEx, path, "<reading all lines>") });
             }
             return lines;
         }

--- a/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
+++ b/ObservatoryCore/UI/ViewModels/CoreViewModel.cs
@@ -112,7 +112,7 @@ namespace Observatory.UI.ViewModels
             try
             {
                 var exportFolder = Properties.Core.Default.ExportFolder;
-                if (string.IsNullOrEmpty(exportFolder))
+                if (string.IsNullOrEmpty(exportFolder) || !Directory.Exists(exportFolder))
                 {
                     exportFolder = System.Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 


### PR DESCRIPTION
Add a try-catch in ReadAllLines to handle a read failure if a file is locked.
Add a check for a non-existing export folder when exporting and prompt for new path if it doesn't exist.