### PR TITLE
Fix for #114: ObservatoryCore does not remember its window state when shut down

### DIFF
--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -214,6 +214,18 @@ namespace Observatory.Properties {
                 this["MainWindowPosition"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public global::System.Int32 MainWindowState {
+            get {
+                return ((global::System.Int32)(this["MainWindowState"]));
+            }
+            set {
+                this["MainWindowState"] = value;
+            }
+        }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]

--- a/ObservatoryCore/Properties/Core.settings
+++ b/ObservatoryCore/Properties/Core.settings
@@ -50,6 +50,9 @@
     <Setting Name="MainWindowPosition" Type="System.Drawing.Point" Scope="User">
       <Value Profile="(Default)">100, 100</Value>
     </Setting>
+    <Setting Name="MainWindowState" Type ="System.Int32" Scope="User"> 
+      <Value Profile="(Default)">0</Value> 
+    </Setting >
     <Setting Name="NativeNotifyScale" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">100</Value>
     </Setting>

--- a/ObservatoryCore/UI/Views/MainWindow.axaml.cs
+++ b/ObservatoryCore/UI/Views/MainWindow.axaml.cs
@@ -15,6 +15,7 @@ namespace Observatory.UI.Views
 #endif
             Height = Properties.Core.Default.MainWindowSize.Height;
             Width = Properties.Core.Default.MainWindowSize.Width;
+            WindowState = (Avalonia.Controls.WindowState)Properties.Core.Default.MainWindowState;
             
             var savedPosition = new System.Drawing.Point(Properties.Core.Default.MainWindowPosition.X, Properties.Core.Default.MainWindowPosition.Y);
             if (PointWithinDesktopWorkingArea(savedPosition))
@@ -28,6 +29,8 @@ namespace Observatory.UI.Views
                 var position = new System.Drawing.Point(Position.X, Position.Y);
                 if (PointWithinDesktopWorkingArea(position))
                     Properties.Core.Default.MainWindowPosition = position;
+
+                Properties.Core.Default.MainWindowState = (int)WindowState;
 
                 Properties.Core.Default.Save();
             };


### PR DESCRIPTION
Important notes:
- This is my first PR for this project
- This is my first attempt at some .net code.
- I do not own Visual Studio --> [Core.Designer.cs](ObservatoryCore/Properties/Core.Designer.cs) has been manually updated, rather than generated by SettingsSingleFileGenerator

Please let me know if I should amend anything! (or if you prefer rejecting this PR, no hard feelings)