### PR TITLE
[Framework] Add a DateTime property for CarrierJumpRequest DepartureTime

### DIFF
--- a/ObservatoryFramework/Files/Journal/FleetCarrier/CarrierJumpRequest.cs
+++ b/ObservatoryFramework/Files/Journal/FleetCarrier/CarrierJumpRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Observatory.Framework.Files.Journal
+﻿using System.Text.Json.Serialization;
+
+namespace Observatory.Framework.Files.Journal
 {
     public class CarrierJumpRequest : JournalBase
     {
@@ -9,5 +11,10 @@
         public string SystemName { get; init; }
         public ulong SystemID { get; init; }
         public string DepartureTime { get; init; }
+
+        [JsonIgnore]
+        public DateTime DepartureTimeDateTime {
+            get => ParseDateTime(DepartureTime);
+        }
     }
 }

--- a/ObservatoryFramework/Files/Journal/JournalBase.cs
+++ b/ObservatoryFramework/Files/Journal/JournalBase.cs
@@ -12,10 +12,7 @@ namespace Observatory.Framework.Files.Journal
         [JsonIgnore]
         public DateTime TimestampDateTime
         {
-            get
-            {
-                return DateTime.ParseExact(Timestamp, "yyyy-MM-ddTHH:mm:ssZ", null, System.Globalization.DateTimeStyles.AssumeUniversal);
-            }
+            get => ParseDateTime(Timestamp);
         }
 
         [JsonPropertyName("event")]
@@ -43,5 +40,17 @@ namespace Observatory.Framework.Files.Journal
 
         private string json;
 
+        // For use by Journal object classes for .*DateTime properties, like TimestampeDateTime, above.
+        internal static DateTime ParseDateTime(string value)
+        {
+            if (DateTime.TryParseExact(value, "yyyy-MM-ddTHH:mm:ssZ", null, System.Globalization.DateTimeStyles.AssumeUniversal, out DateTime dateTimeValue))
+            {
+                return dateTimeValue;
+            }
+            else
+            {
+                return new DateTime();
+            }
+        }
     }
 }

--- a/ObservatoryFramework/Files/ParameterTypes/CurrentGoal.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/CurrentGoal.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualBasic.CompilerServices;
+using Observatory.Framework.Files.Journal;
 using System;
 using System.Numerics;
 
@@ -13,17 +14,7 @@ namespace Observatory.Framework.Files.ParameterTypes
         public string Expiry { get; init; }
         public DateTime ExpiryDateTime
         {
-            get
-            {
-                if (DateTime.TryParseExact(Expiry, "yyyy-MM-ddTHH:mm:ssZ", null, System.Globalization.DateTimeStyles.AssumeUniversal, out DateTime expiryDateTime))
-                {
-                    return expiryDateTime;
-                }
-                else
-                {
-                    return new DateTime();
-                }
-            }
+            get => JournalBase.ParseDateTime(Expiry);
         }
         public bool IsComplete { get; init; }
         public long CurrentTotal { get; init; }


### PR DESCRIPTION
Refactored out the logic backing the JournalBase TimestampDateTime property so it can be used for any DateTime type property, providing a standardized json String -> DateTime conversion for any date-time property. Implemented as an `internal static` method on JournalBase so journal objects which inherit from JournalBase or don't inherit from it can use it.

Used this to provide a DepatureTimeDateTime on CarrierJumpRequest (this property was added in Update 14) and to implement the existing ExpiryDateTime on CurrentGoal.

From a quick search in the journal documentation, I don't see any other applications for this.