### PR TITLE
[Observatory Core] New UI tweaks round 1

### DIFF
--- a/ObservatoryCore/UI/CoreForm.Designer.cs
+++ b/ObservatoryCore/UI/CoreForm.Designer.cs
@@ -471,7 +471,6 @@
             PluginList.MultiSelect = false;
             PluginList.Name = "PluginList";
             PluginList.OwnerDraw = true;
-            PluginList.Scrollable = false;
             PluginList.Size = new Size(659, 137);
             PluginList.TabIndex = 0;
             PluginList.UseCompatibleStateImageBehavior = false;

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -212,6 +212,12 @@ namespace Observatory.UI
 
         private void FitColumns()
         {
+            // This sizes to fit the column width to the text. However, when the listview is resized (by
+            // expanding setting sections below the list), it causes flashing/jank. Visually, it looks cleaner
+            // (because the default column sizes are too small) and helps avoid horizontal scrollbar.
+            //foreach (ColumnHeader col in PluginList.Columns)
+            //    col.Width = -2;
+
             int totalWidth = 0;
             foreach (ColumnHeader col in PluginList.Columns)
                 totalWidth += col.Width;

--- a/ObservatoryCore/UI/SettingsForm.Designer.cs
+++ b/ObservatoryCore/UI/SettingsForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Observatory.UI
+namespace Observatory.UI
 {
     partial class SettingsForm
     {
@@ -50,6 +50,7 @@
             Controls.Add(PluginSettingsCloseButton);
             FormBorderStyle = FormBorderStyle.FixedSingle;
             Name = "SettingsForm";
+            StartPosition = FormStartPosition.CenterScreen;
             Text = "SettingsForm";
             ResumeLayout(false);
         }

--- a/ObservatoryCore/UI/SettingsForm.cs
+++ b/ObservatoryCore/UI/SettingsForm.cs
@@ -18,6 +18,7 @@ namespace Observatory.UI
     {
         private readonly IObservatoryPlugin _plugin;
         private readonly List<int> _colHeight = new List<int>();
+        private int _colWidth = 400;
 
         public SettingsForm(IObservatoryPlugin plugin)
         {
@@ -51,16 +52,18 @@ namespace Observatory.UI
             foreach (var setting in settings)
             {
                 // Reset the column tracking for checkboxes if this isn't a checkbox
+                int addedHeight = 35;
                 if (setting.Key.PropertyType.Name != "Boolean")
+                {
+                    if (recentHalfCol) _colHeight.Add(addedHeight);
                     recentHalfCol = false;
-
-                int addedHeight = 29;
+                }
 
                 switch (setting.Key.GetValue(_plugin.Settings))
                 {
                     case bool:
                         var checkBox = CreateBoolSetting(setting);
-                        addedHeight = recentHalfCol ? 0 : addedHeight;
+                        addedHeight = recentHalfCol ? addedHeight : 0;
                         checkBox.Location = GetSettingPosition(recentHalfCol);
 
                         recentHalfCol = !recentHalfCol;
@@ -111,7 +114,7 @@ namespace Observatory.UI
                         intLabel.Location = GetSettingPosition();
                         intControl.Location = GetSettingPosition(true);
 
-                        addedHeight = intControl.Height;
+                        addedHeight = intControl.Height + 2;
                         intLabel.Height = intControl.Height;
                         intLabel.TextAlign = ContentAlignment.MiddleRight;
 
@@ -125,6 +128,7 @@ namespace Observatory.UI
                         button.Location = GetSettingPosition();
 
                         Controls.Add(button);
+                        addedHeight = button.Height;
                         trackBottomEdge(button);
                         break;
                     case Dictionary<string, object> dictSetting:
@@ -142,12 +146,14 @@ namespace Observatory.UI
                 }
                 _colHeight.Add(addedHeight);
             }
-            Height = settingsHeight + 80;
+            Height = settingsHeight + 160;
+            Width = _colWidth * 2 + 80;
         }
 
         private Point GetSettingPosition(bool secondCol = false)
         {
-            return new Point(10 + (secondCol ? 200 : 0), -26 + _colHeight.Sum());
+            //return new Point(10 + (secondCol ? 200 : 0), -26 + _colHeight.Sum());
+            return new Point(10 + (secondCol ? _colWidth : 0), 15 + _colHeight.Sum());
         }
 
 
@@ -157,7 +163,7 @@ namespace Observatory.UI
             {
                 Text = settingName + ": ",
                 TextAlign = System.Drawing.ContentAlignment.MiddleRight,
-                Width = 200,
+                Width = _colWidth,
                 ForeColor = Color.LightGray
             };
 
@@ -177,7 +183,7 @@ namespace Observatory.UI
 
             ComboBox comboBox = new()
             {
-                Width = 200,
+                Width = _colWidth,
                 DropDownStyle = ComboBoxStyle.DropDownList
             };
 
@@ -203,7 +209,9 @@ namespace Observatory.UI
         {
             Button button = new()
             {
-                Text = settingName
+                Text = settingName,
+                Width = Convert.ToInt32(_colWidth * 0.8),
+                Height = 35,
             };
 
             button.Click += (sender, e) =>
@@ -229,7 +237,7 @@ namespace Observatory.UI
                 Orientation = Orientation.Horizontal,
                 TickStyle = TickStyle.Both,
                 TickFrequency = tickFrequency,
-                Width = 200,
+                Width = _colWidth,
                 Minimum = minBound,
                 Maximum = maxBound,
             };
@@ -250,8 +258,7 @@ namespace Observatory.UI
             SettingNumericBounds? bounds = (SettingNumericBounds?)System.Attribute.GetCustomAttribute(setting, typeof(SettingNumericBounds));
             NumericUpDown numericUpDown = new()
             {
-
-                Width = 200,
+                Width = _colWidth,
                 Minimum = Convert.ToInt32(bounds?.Minimum ?? Int32.MinValue),
                 Maximum = Convert.ToInt32(bounds?.Maximum ?? Int32.MaxValue),
                 Increment = Convert.ToInt32(bounds?.Increment ?? 1)
@@ -275,7 +282,8 @@ namespace Observatory.UI
                 Text = setting.Value,
                 TextAlign = System.Drawing.ContentAlignment.MiddleLeft,
                 Checked = (bool?)setting.Key.GetValue(_plugin.Settings) ?? false,
-                Width = 200,
+                Height = 30,
+                Width = _colWidth,
                 ForeColor = Color.LightGray
             };
 
@@ -293,7 +301,7 @@ namespace Observatory.UI
             TextBox textBox = new()
             {
                 Text = (setting.GetValue(_plugin.Settings) ?? String.Empty).ToString(),
-                Width = 200
+                Width = _colWidth,
             };
 
             textBox.TextChanged += (object? sender, EventArgs e) =>
@@ -312,7 +320,7 @@ namespace Observatory.UI
             TextBox textBox = new()
             {
                 Text = fileInfo?.FullName ?? string.Empty,
-                Width = 200
+                Width = _colWidth,
             };
 
             textBox.TextChanged += (object? sender, EventArgs e) =>
@@ -328,7 +336,9 @@ namespace Observatory.UI
         {
             Button button = new()
             {
-                Text = "Browse"
+                Text = "Browse",
+                Height = 35,
+                Width = _colWidth / 2,
             };
 
             button.Click += (object? sender, EventArgs e) =>

--- a/ObservatoryFramework/Files/Journal/FleetCarrier/CarrierJumpRequest.cs
+++ b/ObservatoryFramework/Files/Journal/FleetCarrier/CarrierJumpRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Observatory.Framework.Files.Journal
+﻿using System.Text.Json.Serialization;
+
+namespace Observatory.Framework.Files.Journal
 {
     public class CarrierJumpRequest : JournalBase
     {
@@ -9,5 +11,10 @@
         public string SystemName { get; init; }
         public ulong SystemID { get; init; }
         public string DepartureTime { get; init; }
+
+        [JsonIgnore]
+        public DateTime DepartureTimeDateTime {
+            get => ParseDateTime(DepartureTime);
+        }
     }
 }

--- a/ObservatoryFramework/Files/Journal/JournalBase.cs
+++ b/ObservatoryFramework/Files/Journal/JournalBase.cs
@@ -12,10 +12,7 @@ namespace Observatory.Framework.Files.Journal
         [JsonIgnore]
         public DateTime TimestampDateTime
         {
-            get
-            {
-                return DateTime.ParseExact(Timestamp, "yyyy-MM-ddTHH:mm:ssZ", null, System.Globalization.DateTimeStyles.AssumeUniversal);
-            }
+            get => ParseDateTime(Timestamp);
         }
 
         [JsonPropertyName("event")]
@@ -43,5 +40,17 @@ namespace Observatory.Framework.Files.Journal
 
         private string json;
 
+        // For use by Journal object classes for .*DateTime properties, like TimestampeDateTime, above.
+        internal static DateTime ParseDateTime(string value)
+        {
+            if (DateTime.TryParseExact(value, "yyyy-MM-ddTHH:mm:ssZ", null, System.Globalization.DateTimeStyles.AssumeUniversal, out DateTime dateTimeValue))
+            {
+                return dateTimeValue;
+            }
+            else
+            {
+                return new DateTime();
+            }
+        }
     }
 }

--- a/ObservatoryFramework/Files/ParameterTypes/CurrentGoal.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/CurrentGoal.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualBasic.CompilerServices;
+using Observatory.Framework.Files.Journal;
 using System;
 using System.Numerics;
 
@@ -13,17 +14,7 @@ namespace Observatory.Framework.Files.ParameterTypes
         public string Expiry { get; init; }
         public DateTime ExpiryDateTime
         {
-            get
-            {
-                if (DateTime.TryParseExact(Expiry, "yyyy-MM-ddTHH:mm:ssZ", null, System.Globalization.DateTimeStyles.AssumeUniversal, out DateTime expiryDateTime))
-                {
-                    return expiryDateTime;
-                }
-                else
-                {
-                    return new DateTime();
-                }
-            }
+            get => JournalBase.ParseDateTime(Expiry);
         }
         public bool IsComplete { get; init; }
         public long CurrentTotal { get; init; }


### PR DESCRIPTION
Polishing a few rough edges with the Core/Settings UI:

* Enable scrolling on the Plugin List view. It only fit 6 or 7. I have 13. Really hard to access settings.
* I fiddled a bit with column auto-sizing (left it commented out, see comment, but I'd like to see if this can be improved further).
* A whole bunch of tweaks to the settings view:
  * first row of controls was cut off at the top (under the window title bar)
  * fixing that revealed uneven spacing between columns (ie. second column of checkboxes had a blank space at the top)
  * action buttons were teensy tiny and unreadable
  * settings view columns were too narrow, most labels were cut off (only 200 px wide) -- some still are cut off.
  * added some spacing to help with readability
  * settings windows now start in center of current screen rather than some random place.

After these changes, this is what Explorer settings UI looks like:
![image](https://github.com/Xjph/ObservatoryCore/assets/54195004/7f15e7c4-0e26-4206-90d4-6d655329b91c)

More to come...
