### PR TITLE
[Explorer] Default + Custom Criteria improvements

### DIFF
--- a/ObservatoryExplorer/CustomCriteriaManager.cs
+++ b/ObservatoryExplorer/CustomCriteriaManager.cs
@@ -189,11 +189,10 @@ namespace Observatory.Explorer
             {
                 for (int i = 0; i < criteria.Length; i++)
                 {
-                    bool isDisabled = criteria[i].Trim().ToLower().StartsWith("::--");
                     if (criteria[i].Trim().StartsWith("::"))
                     {
                         string scriptDescription = criteria[i].Trim().Replace("::", string.Empty);
-                        if (scriptDescription.ToLower() == "criteria" || scriptDescription.ToLower().StartsWith("criteria=") || scriptDescription.ToLower().StartsWith("--criteria"))
+                        if (scriptDescription.ToLower() == "criteria" || scriptDescription.ToLower().StartsWith("criteria="))
                         {
                             string functionName = $"Criteria{i}";
                             script.AppendLine($"function {functionName} (scan, parents, system, biosignals, geosignals)");
@@ -208,11 +207,8 @@ namespace Observatory.Explorer
                             } while (!criteria[i].Trim().ToLower().StartsWith("::end::"));
                             script.AppendLine("end");
 
-                            if (!isDisabled)
-                            {
-                                LuaState.DoString(script.ToString());
-                                CriteriaFunctions.Add(GetUniqueDescription(functionName, scriptDescription), LuaState[functionName] as LuaFunction);
-                            }
+                            LuaState.DoString(script.ToString());
+                            CriteriaFunctions.Add(GetUniqueDescription(functionName, scriptDescription), LuaState[functionName] as LuaFunction);
                             script.Clear();
                         }
                         else if (scriptDescription.ToLower() == "global")

--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -104,8 +104,9 @@ namespace Observatory.Explorer
                         if (separation < scan.Radius * 10)
                         {
                             var ringTypeName = ring.Name.Contains("Belt") ? "Belt" : "Ring";
+                            var isLandable = scan.Landable ? ", Landable" : "";
                             results.Add($"Close {ringTypeName} Proximity",
-                                $"Orbit: {scan.SemiMajorAxis / 1000:N0}km, Radius: {scan.Radius / 1000:N0}km, Distance from {ringTypeName.ToLower()}: {separation / 1000:N0}km");
+                                $"Orbit: {scan.SemiMajorAxis / 1000:N0}km, Radius: {scan.Radius / 1000:N0}km, Distance from {ringTypeName.ToLower()}: {separation / 1000:N0}km{isLandable}");
                         }
                     }
                 }
@@ -130,7 +131,8 @@ namespace Observatory.Explorer
                     var ringWidth = ring.OuterRad - ring.InnerRad;
                     if (ringWidth > scan.Radius * 5)
                     {
-                        results.Add("Wide Ring", $"Width: {ringWidth / 299792458:N2}Ls / {ringWidth / 1000:N0}km, Parent Radius: {scan.Radius / 1000:N0}km");
+                        var ringName = ring.Name.Replace(scan.BodyName, "").Trim();
+                        results.Add("Wide Ring", $"{ringName}: Width: {ringWidth / 299792458:N2}Ls / {ringWidth / 1000:N0}km, Parent Radius: {scan.Radius / 1000:N0}km");
                     }
                 }
             }

--- a/ObservatoryExplorer/Explorer.cs
+++ b/ObservatoryExplorer/Explorer.cs
@@ -188,7 +188,6 @@ namespace Observatory.Explorer
                                 Details = e.OriginalScript
                             };
                             ObservatoryCore.AddGridItem(ExplorerWorker, exceptionResult);
-                            ExplorerWorker.settings.EnableCustomCriteria = false;
                         }
                         
                         CriteriaLastModified = fileModified;


### PR DESCRIPTION
For Custom Criteria:
* You can now disable a CC by inserting a `--` in the first line of the criteria; eg: `::--Criteria::`
* If a custom criteria throws an error or fails to parse/load, Core no longer disables custom criteria entirely -- it now disables the problematic criteria until you update the custom criteria file and trigger a new journal/re-read (which reloads the source file).

For Default Criteria:
* Adds landable status of the body triggering the Close Ring/Belt proximity. (Requested in Discord somewhere.)
* Adds the triggering ring name to the Wide Ring criteria. (I believe also requested, can't remember now.)