### PR TITLE
[Framework] Add 3 new properties to NotificationArgs to expand detail

### DIFF
--- a/ObservatoryExplorer/Explorer.cs
+++ b/ObservatoryExplorer/Explorer.cs
@@ -240,6 +240,7 @@ namespace Observatory.Explorer
             if (results.Count > 0)
             {
                 StringBuilder notificationDetail = new();
+                StringBuilder notificationExtendedDetail = new();
                 foreach (var result in results)
                 {
                     var scanResult = new ExplorerUIResults()
@@ -251,6 +252,7 @@ namespace Observatory.Explorer
                     };
                     ObservatoryCore.AddGridItem(ExplorerWorker, scanResult);
                     notificationDetail.AppendLine(result.Description);
+                    notificationExtendedDetail.AppendLine(result.Detail);
                 }
 
                 string bodyAffix;
@@ -293,7 +295,10 @@ namespace Observatory.Explorer
                 {
                     Title = bodyLabel + bodyAffix,
                     TitleSsml = $"<speak version=\"1.0\" xmlns=\"http://www.w3.org/2001/10/synthesis\" xml:lang=\"en-US\"><voice name=\"\">{bodyLabel} {spokenAffix}</voice></speak>",
-                    Detail = notificationDetail.ToString()
+                    Detail = notificationDetail.ToString(),
+                    Sender = ExplorerWorker.ShortName,
+                    ExtendedDetails = notificationExtendedDetail.ToString(),
+                    CoalescingId = scanEvent.BodyID,
                 };
 
                 ObservatoryCore.SendNotification(args);

--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -62,6 +62,18 @@ namespace Observatory.Framework
         /// Specifies if some part of the notification should be suppressed. Not supported by all notifiers. Defaults to <see cref="NotificationSuppression.None"/>.
         /// </summary>
         public NotificationSuppression Suppression = NotificationSuppression.None;
+        /// <summary>
+        /// The plugin sending this notification.
+        /// </summary>
+        public string Sender = "";
+        /// <summary>
+        /// Additional notification detailed (generally not rendered by voice or popup; potentially used by aggregating/logging plugins).
+        /// </summary>
+        public string ExtendedDetails;
+        /// <summary>
+        /// A value which allows grouping of notifications together. For example, values &gt;= 0 &lt;= 1000 could be system body IDs, -1 is the system, anything else is arbitrary.
+        /// </summary>
+        public int CoalescingId;
     }
 
     /// <summary>

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -148,6 +148,21 @@
             Specifies if some part of the notification should be suppressed. Not supported by all notifiers. Defaults to <see cref="F:Observatory.Framework.NotificationSuppression.None"/>.
             </summary>
         </member>
+        <member name="F:Observatory.Framework.NotificationArgs.Sender">
+            <summary>
+            The plugin sending this notification.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationArgs.ExtendedDetails">
+            <summary>
+            Additional notification detailed (generally not rendered by voice or popup; potentially used by aggregating/logging plugins).
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.NotificationArgs.CoalescingId">
+            <summary>
+            A value which allows grouping of notifications together. For example, values &gt;= 0 &lt;= 1000 could be system body IDs, -1 is the system, anything else is arbitrary.
+            </summary>
+        </member>
         <member name="T:Observatory.Framework.NotificationSuppression">
             <summary>
             Defines constants for suppression of title or detail announcement in a notification.


### PR DESCRIPTION
The new properties are:

* string Sender: The name of the plugin sending the notification.
* string ExtendedDetails: Even more detail than Title and Detail convey. This value will not be spoken nor included in pop-up notifications. However, other notifier plugins may use this value.
* int ColescingId: An id which can be used to correlate multiple notifications together (ie. for sorting/grouping) without depending on arbitrary string values. I recommend reserving -1 for system, 0 .. 1000 for system bodies and anything else is arbitrary and can be agreed upon between Core and Plugin authors, as desired.

While the motivating use is a new notifier plugin I am authoring (my Aggregator plugin, see GitHub), I have tried to make this as general purpose as possible.

I have modified Explorer as an example of usage. After this is merged, I'll follow up with another PR to use this in Botanist as well (I have other changes pending for Botanist; see #120).

Comments welcomed!