### PR TITLE
[Herald] Herald as native voice

### DIFF
--- a/ObservatoryHerald/HeraldNotifier.cs
+++ b/ObservatoryHerald/HeraldNotifier.cs
@@ -77,7 +77,7 @@ namespace Observatory.Herald
 
         public void OnNotificationEvent(NotificationArgs notificationEventArgs)
         {
-            if (heraldSettings.Enabled)
+            if (heraldSettings.Enabled && notificationEventArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
                 heraldSpeech.Enqueue(
                     notificationEventArgs, 
                     GetAzureNameFromSetting(heraldSettings.SelectedVoice),


### PR DESCRIPTION
This makes Herald, a plugin ONLY react to NativeVocal notifications so notifications can be sent silently by using `Rendering = NotificationRendering.PluginNotifier` on NotificationArgs. These notifications will be picked up by other notification listeners (eg. Aggregator).