### PR TITLE
[Core] Improve(?) Plugin List column sizing

### DIFF
--- a/ObservatoryCore/UI/CoreForm.Plugins.cs
+++ b/ObservatoryCore/UI/CoreForm.Plugins.cs
@@ -32,6 +32,9 @@ namespace Observatory.UI
                     PluginList.Items.Add(item);
                 }
             }
+
+            PluginList.AutoResizeColumns(ColumnHeaderAutoResizeStyle.ColumnContent);
+            PluginList.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
         }
 
         private static string PluginStatusString(PluginManager.PluginStatus status)

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -212,17 +212,11 @@ namespace Observatory.UI
 
         private void FitColumns()
         {
-            // This sizes to fit the column width to the text. However, when the listview is resized (by
-            // expanding setting sections below the list), it causes flashing/jank. Visually, it looks cleaner
-            // (because the default column sizes are too small) and helps avoid horizontal scrollbar.
-            //foreach (ColumnHeader col in PluginList.Columns)
-            //    col.Width = -2;
-
             int totalWidth = 0;
             foreach (ColumnHeader col in PluginList.Columns)
                 totalWidth += col.Width;
 
-            PluginList.Columns[3].Width += PluginList.Width - totalWidth;
+            PluginList.Columns[3].Width += PluginList.Width - totalWidth - 1 - SystemInformation.VerticalScrollBarWidth;
         }
 
         private void ReadAllButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
After populating the list of plugins, auto-size the columns once. In the Resize event handler, do what you did before but account for the scrollbar width too. Prevents horizontal scrollbar appearing except for really fast resize movements.

I didn't try it yet with fewer than a scrollable # of plugins yet.

This cleans up my commented out code from #128.

![image](https://github.com/Xjph/ObservatoryCore/assets/54195004/65de39a3-89a7-402f-b11e-08def35b80ac)
