### PR TITLE
[Core] Fix: Convert Decimal control values to int32 for Int settings

### DIFF
--- a/ObservatoryCore/UI/SettingsForm.cs
+++ b/ObservatoryCore/UI/SettingsForm.cs
@@ -246,7 +246,7 @@ namespace Observatory.UI
 
             trackBar.ValueChanged += (sender, e) =>
             {
-                setting.SetValue(_plugin.Settings, trackBar.Value);
+                setting.SetValue(_plugin.Settings, Convert.ToInt32(trackBar.Value));
                 SaveSettings();
             };
 
@@ -268,7 +268,7 @@ namespace Observatory.UI
 
             numericUpDown.ValueChanged += (sender, e) =>
             {
-                setting.SetValue(_plugin.Settings, numericUpDown.Value);
+                setting.SetValue(_plugin.Settings, Convert.ToInt32(numericUpDown.Value));
                 SaveSettings();
             };
 


### PR DESCRIPTION
Attempting to set decimal values to int properties tends to throw errors. ;-)