### PR TITLE
[Botanist] Localization fixes, setting for sampler overlay, ui overhaul

### DIFF
--- a/ObservatoryBotanist/BotanistSettings.cs
+++ b/ObservatoryBotanist/BotanistSettings.cs
@@ -11,5 +11,7 @@ namespace Observatory.Botanist
     {
         [SettingDisplayName("Enable Sampler Status Overlay")]
         public bool OverlayEnabled { get; set; }
+        [SettingDisplayName("Sampler Status Overlay is sticky until sampling complete (if enabled)")]
+        public bool OverlayIsSticky { get; set; }
     }
 }


### PR DESCRIPTION
Previously the Sampler overlay notification was sticky (ie. it stuck around until you completed sampling). This change adds an option (by request) to make it not-sticky (so it disappears after the configured timeout, like other notifications). Default will be sticky.

It was also observed that for non-English users, all the colony distances were 100m (effectively default) because the Genus_Localised field was being used for lookups, failing and thunking to default. Furthermore, the notification would display a mix of languages. With this update, we use the identifier (ie. the Genus field) and map to English names and this should provide consistent language output and lookup of colony distances. This also adds support for Horizons bios that can be sampled.

2 minor changes to support the ui-overhaul:
- Assign grid column widths
- Add Sender to NotificationArgs for the sampler status overlay.

Supercedes #120