### PR TITLE
[Herald+Core] Send notifications to plugins during read-all in Debug

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -46,13 +46,22 @@ namespace Observatory.PluginManagement
         {
             var guid = Guid.Empty;
 
+#if DEBUG // For exercising testing notifier plugins in read-all
+            if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
+            {
+                var handler = Notification;
+                handler?.Invoke(this, notificationArgs);
+            }
+#endif
             if (!IsLogMonitorBatchReading)
             {
+#if !DEBUG
                 if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
                 {
                     var handler = Notification;
                     handler?.Invoke(this, notificationArgs);
                 }
+#endif
 
                 if (!OverridePopup && Properties.Core.Default.NativeNotify && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVisual))
                 {

--- a/ObservatoryHerald/HeraldNotifier.cs
+++ b/ObservatoryHerald/HeraldNotifier.cs
@@ -6,6 +6,8 @@ namespace Observatory.Herald
 {
     public class HeraldNotifier : IObservatoryNotifier
     {
+        private IObservatoryCore Core;
+
         public HeraldNotifier()
         {
             heraldSettings = DefaultSettings;
@@ -53,8 +55,10 @@ namespace Observatory.Herald
                 }
             }
         }
+
         public void Load(IObservatoryCore observatoryCore)
         {
+            Core = observatoryCore;
             var speechManager = new SpeechRequestManager(
                 heraldSettings, observatoryCore.HttpClient, observatoryCore.PluginStorageFolder, observatoryCore.GetPluginErrorLogger(this));
             heraldSpeech = new HeraldQueue(speechManager, observatoryCore.GetPluginErrorLogger(this), observatoryCore);
@@ -77,6 +81,8 @@ namespace Observatory.Herald
 
         public void OnNotificationEvent(NotificationArgs notificationEventArgs)
         {
+            if (Core.IsLogMonitorBatchReading) return;
+
             if (heraldSettings.Enabled && notificationEventArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
                 heraldSpeech.Enqueue(
                     notificationEventArgs, 


### PR DESCRIPTION
This will allow notifications to be sent to Notification listeners during read-all to enhance testability.

This is controlled by the `DEBUG` compiler directive, so Release versions will not have this behaviour.

However, Herald, being a plugin itself, should ignore these otherwise the results are.... unfortunate. #askmehowiknow