### PR TITLE
[Core] Spit and polish on PluginList and tabs

### DIFF
--- a/ObservatoryCore/App.config
+++ b/ObservatoryCore/App.config
@@ -76,6 +76,9 @@
             <setting name="ColumnSizing" serializeAs="String">
                 <value />
             </setting>
+            <setting name="PluginsEnabled" serializeAs="String">
+                <value />
+            </setting>
         </Observatory.Properties.Core>
     </userSettings>
 </configuration>

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -36,12 +36,13 @@ namespace Observatory.PluginManagement
         public readonly List<(IObservatoryWorker plugin, PluginStatus signed)> workerPlugins;
         public readonly List<(IObservatoryNotifier plugin, PluginStatus signed)> notifyPlugins;
         private readonly PluginCore core;
+        private readonly PluginEventHandler pluginHandler;
         
         private PluginManager()
         {
             errorList = LoadPlugins(out workerPlugins, out notifyPlugins);
 
-            var pluginHandler = new PluginEventHandler(workerPlugins.Select(p => p.plugin), notifyPlugins.Select(p => p.plugin));
+            pluginHandler = new PluginEventHandler(workerPlugins.Select(p => p.plugin), notifyPlugins.Select(p => p.plugin));
             var logMonitor = LogMonitor.GetInstance;
             pluginPanels = new();
             pluginTables = new();
@@ -194,6 +195,11 @@ namespace Observatory.PluginManagement
 
             Properties.Core.Default.PluginSettings = newSettings;
             SettingsManager.Save();
+        }
+
+        public void SetPluginEnabled(IObservatoryPlugin plugin, bool enabled)
+        {
+            pluginHandler.SetPluginEnabled(plugin, enabled);
         }
 
         private static List<(string, string?)> LoadPlugins(out List<(IObservatoryWorker plugin, PluginStatus signed)> observatoryWorkers, out List<(IObservatoryNotifier plugin, PluginStatus signed)> observatoryNotifiers)

--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -309,5 +309,17 @@ namespace Observatory.Properties {
                 this["ColumnSizing"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string PluginsEnabled {
+            get {
+                return ((string)(this["PluginsEnabled"]));
+            }
+            set {
+                this["PluginsEnabled"] = value;
+            }
+        }
     }
 }

--- a/ObservatoryCore/Properties/Core.settings
+++ b/ObservatoryCore/Properties/Core.settings
@@ -74,5 +74,8 @@
     <Setting Name="ColumnSizing" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="PluginsEnabled" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ObservatoryCore/UI/CoreForm.Designer.cs
+++ b/ObservatoryCore/UI/CoreForm.Designer.cs
@@ -136,7 +136,7 @@
             // 
             ThemeLabel.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             ThemeLabel.BorderStyle = BorderStyle.FixedSingle;
-            ThemeLabel.Location = new Point(3, 603);
+            ThemeLabel.Location = new Point(3, 656);
             ThemeLabel.Name = "ThemeLabel";
             ThemeLabel.Size = new Size(659, 23);
             ThemeLabel.TabIndex = 7;
@@ -148,7 +148,7 @@
             PluginSettingsButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             PluginSettingsButton.FlatAppearance.BorderSize = 0;
             PluginSettingsButton.FlatStyle = FlatStyle.Flat;
-            PluginSettingsButton.Location = new Point(396, 140);
+            PluginSettingsButton.Location = new Point(396, 193);
             PluginSettingsButton.Name = "PluginSettingsButton";
             PluginSettingsButton.Size = new Size(130, 23);
             PluginSettingsButton.TabIndex = 6;
@@ -167,7 +167,7 @@
             VoiceSettingsPanel.Controls.Add(VoiceLabel);
             VoiceSettingsPanel.Controls.Add(VoiceSpeedLabel);
             VoiceSettingsPanel.Controls.Add(VoiceVolumeLabel);
-            VoiceSettingsPanel.Location = new Point(3, 426);
+            VoiceSettingsPanel.Location = new Point(3, 479);
             VoiceSettingsPanel.Name = "VoiceSettingsPanel";
             VoiceSettingsPanel.Size = new Size(659, 177);
             VoiceSettingsPanel.TabIndex = 5;
@@ -262,7 +262,7 @@
             // 
             VoiceNotificationLabel.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             VoiceNotificationLabel.BorderStyle = BorderStyle.FixedSingle;
-            VoiceNotificationLabel.Location = new Point(3, 403);
+            VoiceNotificationLabel.Location = new Point(3, 456);
             VoiceNotificationLabel.Name = "VoiceNotificationLabel";
             VoiceNotificationLabel.Size = new Size(659, 23);
             VoiceNotificationLabel.TabIndex = 4;
@@ -287,7 +287,7 @@
             PopupSettingsPanel.Controls.Add(DisplayDropdown);
             PopupSettingsPanel.Controls.Add(CornerLabel);
             PopupSettingsPanel.Controls.Add(DisplayLabel);
-            PopupSettingsPanel.Location = new Point(3, 195);
+            PopupSettingsPanel.Location = new Point(3, 248);
             PopupSettingsPanel.Name = "PopupSettingsPanel";
             PopupSettingsPanel.Size = new Size(659, 208);
             PopupSettingsPanel.TabIndex = 3;
@@ -440,7 +440,7 @@
             // 
             PopupNotificationLabel.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             PopupNotificationLabel.BorderStyle = BorderStyle.FixedSingle;
-            PopupNotificationLabel.Location = new Point(3, 172);
+            PopupNotificationLabel.Location = new Point(3, 225);
             PopupNotificationLabel.Name = "PopupNotificationLabel";
             PopupNotificationLabel.Size = new Size(659, 23);
             PopupNotificationLabel.TabIndex = 2;
@@ -453,7 +453,7 @@
             PluginFolderButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             PluginFolderButton.FlatAppearance.BorderSize = 0;
             PluginFolderButton.FlatStyle = FlatStyle.Flat;
-            PluginFolderButton.Location = new Point(532, 140);
+            PluginFolderButton.Location = new Point(532, 193);
             PluginFolderButton.Name = "PluginFolderButton";
             PluginFolderButton.Size = new Size(130, 23);
             PluginFolderButton.TabIndex = 1;
@@ -464,17 +464,20 @@
             // 
             PluginList.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             PluginList.BorderStyle = BorderStyle.None;
+            PluginList.CheckBoxes = true;
             PluginList.Columns.AddRange(new ColumnHeader[] { NameColumn, TypeColumn, VersionColumn, StatusColumn });
+            PluginList.FullRowSelect = true;
             PluginList.HeaderStyle = ColumnHeaderStyle.Nonclickable;
             PluginList.ImeMode = ImeMode.NoControl;
             PluginList.Location = new Point(3, 3);
             PluginList.MultiSelect = false;
             PluginList.Name = "PluginList";
             PluginList.OwnerDraw = true;
-            PluginList.Size = new Size(659, 137);
+            PluginList.Size = new Size(659, 184);
             PluginList.TabIndex = 0;
             PluginList.UseCompatibleStateImageBehavior = false;
             PluginList.View = View.Details;
+            PluginList.ItemChecked += PluginList_ItemChecked;
             PluginList.Resize += PluginList_Resize;
             // 
             // NameColumn

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -112,10 +112,10 @@ namespace Observatory.UI
                     if (menuItem.Value.Text == "<")
                         menuItem.Value.Text = ">";
                     else
-                        menuItem.Value.Text = menuItem.Key[..1];
+                        menuItem.Value.Text = menuItem.Key[..3];
                 }
-                CoreMenu.Width = 40;
-                ResizePanels(new Point(43, 12), 0);
+                CoreMenu.Width = 110;
+                ResizePanels(new Point(CoreMenu.Width + 3, 12), 0);
             }
             else if (e.ClickedItem.Text == ">")
             {

--- a/ObservatoryCore/UI/PluginHelper.cs
+++ b/ObservatoryCore/UI/PluginHelper.cs
@@ -17,7 +17,7 @@ namespace Observatory.UI
         internal static List<string> CreatePluginTabs(MenuStrip menu, IEnumerable<(IObservatoryWorker plugin, PluginManagement.PluginManager.PluginStatus signed)> plugins, Dictionary<object, Panel> uiPanels)
         {
             List<string> pluginList = new List<string>();
-            foreach (var plugin in plugins)
+            foreach (var plugin in plugins.OrderBy(p => p.plugin.ShortName))
             {
                 AddPlugin(menu, plugin.plugin, plugin.signed, uiPanels);
                 pluginList.Add(plugin.plugin.ShortName);
@@ -28,7 +28,7 @@ namespace Observatory.UI
         internal static List<string> CreatePluginTabs(MenuStrip menu, IEnumerable<(IObservatoryNotifier plugin, PluginManagement.PluginManager.PluginStatus signed)> plugins, Dictionary<object, Panel> uiPanels)
         {
             List<string> pluginList = new List<string>();
-            foreach (var plugin in plugins)
+            foreach (var plugin in plugins.OrderBy(p => p.plugin.ShortName))
             {
                 AddPlugin(menu, plugin.plugin, plugin.signed, uiPanels);
                 pluginList.Add(plugin.plugin.ShortName);
@@ -73,12 +73,13 @@ namespace Observatory.UI
                 View = View.Details,
                 Location = new Point(0, 0),
                 Size = panel.Size,
-                Anchor = AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Bottom | AnchorStyles.Top,
+                Dock = DockStyle.Fill,
                 BackColor = Color.FromArgb(64, 64, 64),
                 ForeColor = Color.LightGray,
                 ListViewItemSorter = columnSorter,
                 Font = new Font(new FontFamily("Segoe UI"), 10, FontStyle.Regular)
             };
+            panel.Controls.Add(listView);
 
             string colSize = Properties.Core.Default.ColumnSizing;
             List<ColumnSizing>? columnSizing = null;
@@ -212,8 +213,6 @@ namespace Observatory.UI
                 }
                 listView.Sort();
             };
-
-            panel.Controls.Add(listView);
 
             plugin.PluginUI.DataGrid.CollectionChanged += (sender, e) =>
             {


### PR DESCRIPTION
Add checkboxes to the PluginList which allow you to enable/disable each plugin on-the-fly (it will no longer respond to events, but you can still configure it, etc.). These settings are preserved in a new Core setting. Also enabled full-row select for easier selection in the listview.

Also increased the height of the PluginList slightly. (Personally, I'd like it even taller.)

Also made slight sizing adjustments to the plugin tabs, which now show 3 letters when collapsed and has a bit of extra space so the longest one does not get cut-off when selected/bolded. Furthermore, the list of plugins is now sorted alphabetically.

Finally, set the plugin listview Dock = Fill (vs. Anchored).

![image](https://github.com/Xjph/ObservatoryCore/assets/54195004/cdd11c1a-e503-4ba1-9fe2-e44101acf378)
