### PR TITLE
[Core] Fix "not all code paths return a value" error when publishing

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -147,7 +147,11 @@ namespace Observatory.PluginManagement
             get
             {
                 var context = new System.Diagnostics.StackFrame(1).GetMethod();
-#if DEBUG || RELEASE
+#if PORTABLE
+                string? observatoryLocation = System.Diagnostics.Process.GetCurrentProcess()?.MainModule?.FileName;
+                var obsDir = new FileInfo(observatoryLocation ?? String.Empty).DirectoryName;
+                return $"{obsDir}{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}{context?.DeclaringType?.Assembly.GetName().Name}-Data{Path.DirectorySeparatorChar}";
+#else
                 string folderLocation = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
                     + $"{Path.DirectorySeparatorChar}ObservatoryCore{Path.DirectorySeparatorChar}{context?.DeclaringType?.Assembly.GetName().Name}{Path.DirectorySeparatorChar}";
 
@@ -155,10 +159,6 @@ namespace Observatory.PluginManagement
                     Directory.CreateDirectory(folderLocation);
 
                 return folderLocation;
-#elif PORTABLE
-                string? observatoryLocation = System.Diagnostics.Process.GetCurrentProcess()?.MainModule?.FileName;
-                var obsDir = new FileInfo(observatoryLocation ?? String.Empty).DirectoryName;
-                return $"{obsDir}{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}{context?.DeclaringType?.Assembly.GetName().Name}-Data{Path.DirectorySeparatorChar}";
 #endif
             }
         }


### PR DESCRIPTION
Just shuffled code within conditional compiler directives because when publishing, it seems "RELEASE" is not set. This ensures in the non PORTABLE case, the default path is set.

(Discovered while testing my publishing script with signing.)