### PR TITLE
[Core] Make Prereading the default behavior, re-enable settings upgrade

### DIFF
--- a/ObservatoryCore/ObservatoryCore.cs
+++ b/ObservatoryCore/ObservatoryCore.cs
@@ -30,7 +30,7 @@ namespace Observatory
                 {
                     try
                     {
-                        // Properties.Core.Default.Upgrade();
+                        Properties.Core.Default.Upgrade();
                     }
                     catch 
                     {

--- a/ObservatoryCore/Utils/LogMonitor.cs
+++ b/ObservatoryCore/Utils/LogMonitor.cs
@@ -119,8 +119,7 @@ namespace Observatory.Utils
 
         public void PrereadJournals()
         {
-            if (!Properties.Core.Default.TryPrimeSystemContextOnStartMonitor ||
-                Properties.Core.Default.StartReadAll) return;
+            if (Properties.Core.Default.StartReadAll) return;
 
             SetLogMonitorState(currentState | LogMonitorState.PreRead);
 


### PR DESCRIPTION
Pre-reading is good. And turns out a number of plugins kinda depend on it now. Time to make it default.

Also, uncomment settings upgrades so settings are carried over from version to version when running in the IDE -- which makes using it far better.