### PR TITLE
[Framework] Make the new CoalescingId event arg nullable

### DIFF
--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -73,7 +73,7 @@ namespace Observatory.Framework
         /// <summary>
         /// A value which allows grouping of notifications together. For example, values &gt;= 0 &lt;= 1000 could be system body IDs, -1 is the system, anything else is arbitrary.
         /// </summary>
-        public int CoalescingId;
+        public int? CoalescingId;
     }
 
     /// <summary>


### PR DESCRIPTION
While testing, I discovered that plugins that don't yet support sending the Coalescing ID were not mixing well because the default value of the ID is 0 -- which is also a valid body id. If the default is null, receivers can detect the absent value and apply a sensible default (ie. group them where it makes sense).