### PR TITLE
[Core] Visual improvements to notifications

### DIFF
--- a/ObservatoryCore/UI/CoreForm.Designer.cs
+++ b/ObservatoryCore/UI/CoreForm.Designer.cs
@@ -402,7 +402,7 @@
             FontDropdown.FormattingEnabled = true;
             FontDropdown.Location = new Point(120, 65);
             FontDropdown.Name = "FontDropdown";
-            FontDropdown.Size = new Size(121, 23);
+            FontDropdown.Size = new Size(242, 23);
             FontDropdown.TabIndex = 5;
             FontDropdown.SelectedIndexChanged += FontDropdown_SelectedIndexChanged;
             // 

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -264,7 +264,7 @@ namespace Observatory.UI
         {
             NotificationArgs args = new()
             {
-                Title = "Test Notification",
+                Title = "Test Popup Notification",
                 Detail = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec at elit maximus, ornare dui nec, accumsan velit. Vestibulum fringilla elit."
             };
 

--- a/ObservatoryCore/UI/NotificationForm.Designer.cs
+++ b/ObservatoryCore/UI/NotificationForm.Designer.cs
@@ -34,12 +34,12 @@ namespace Observatory.UI
             // 
             // Title
             // 
-            Title.Font = new Font("Segoe UI", 20F, FontStyle.Regular, GraphicsUnit.Point);
+            Title.Font = new Font("Segoe UI", 18F, FontStyle.Regular, GraphicsUnit.Point);
             Title.ForeColor = Color.OrangeRed;
             Title.Location = new Point(5, 5);
             Title.MaximumSize = new Size(345, 45);
             Title.Name = "Title";
-            Title.Size = new Size(338, 45);
+            Title.Size = new Size(338, 35);
             Title.TabIndex = 0;
             Title.Text = "Title";
             Title.UseCompatibleTextRendering = true;

--- a/ObservatoryCore/UI/NotificationForm.Designer.cs
+++ b/ObservatoryCore/UI/NotificationForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace Observatory.UI
+namespace Observatory.UI
 {
     partial class NotificationForm
     {
@@ -37,11 +37,12 @@
             Title.Font = new Font("Segoe UI", 24F, FontStyle.Regular, GraphicsUnit.Point);
             Title.ForeColor = Color.OrangeRed;
             Title.Location = new Point(5, 5);
-            Title.MaximumSize = new Size(355, 0);
+            Title.MaximumSize = new Size(345, 45);
             Title.Name = "Title";
             Title.Size = new Size(338, 45);
             Title.TabIndex = 0;
             Title.Text = "Title";
+            Title.UseCompatibleTextRendering = true;
             // 
             // Body
             // 
@@ -74,6 +75,7 @@
             ShowIcon = false;
             ShowInTaskbar = false;
             Text = "NotificationForm";
+            TransparencyKey = Color.FromArgb(64, 64, 64);
             ResumeLayout(false);
             PerformLayout();
         }

--- a/ObservatoryCore/UI/NotificationForm.Designer.cs
+++ b/ObservatoryCore/UI/NotificationForm.Designer.cs
@@ -34,7 +34,7 @@ namespace Observatory.UI
             // 
             // Title
             // 
-            Title.Font = new Font("Segoe UI", 24F, FontStyle.Regular, GraphicsUnit.Point);
+            Title.Font = new Font("Segoe UI", 20F, FontStyle.Regular, GraphicsUnit.Point);
             Title.ForeColor = Color.OrangeRed;
             Title.Location = new Point(5, 5);
             Title.MaximumSize = new Size(345, 45);
@@ -50,7 +50,7 @@ namespace Observatory.UI
             Body.AutoSize = true;
             Body.Font = new Font("Segoe UI", 14.25F, FontStyle.Regular, GraphicsUnit.Point);
             Body.ForeColor = Color.OrangeRed;
-            Body.Location = new Point(12, 45);
+            Body.Location = new Point(12, 40);
             Body.MaximumSize = new Size(320, 85);
             Body.Name = "Body";
             Body.Size = new Size(51, 31);

--- a/ObservatoryCore/UI/NotificationForm.cs
+++ b/ObservatoryCore/UI/NotificationForm.cs
@@ -62,7 +62,7 @@ namespace Observatory.UI
 
             Title.ForeColor = _color;
             Title.Text = args.Title;
-            Title.Font = new Font(Properties.Core.Default.NativeNotifyFont, 20);
+            Title.Font = new Font(Properties.Core.Default.NativeNotifyFont, 18);
             Body.ForeColor = _color;
             Body.Text = args.Detail;
             Body.Font = new Font(Properties.Core.Default.NativeNotifyFont, 14);

--- a/ObservatoryCore/UI/NotificationForm.cs
+++ b/ObservatoryCore/UI/NotificationForm.cs
@@ -62,7 +62,7 @@ namespace Observatory.UI
 
             Title.ForeColor = _color;
             Title.Text = args.Title;
-            Title.Font = new Font(Properties.Core.Default.NativeNotifyFont, 24);
+            Title.Font = new Font(Properties.Core.Default.NativeNotifyFont, 20);
             Body.ForeColor = _color;
             Body.Text = args.Detail;
             Body.Font = new Font(Properties.Core.Default.NativeNotifyFont, 14);

--- a/ObservatoryCore/UI/NotificationForm.cs
+++ b/ObservatoryCore/UI/NotificationForm.cs
@@ -203,7 +203,7 @@ namespace Observatory.UI
             if (sender != null)
             {
                 var label = (Label)sender;
-                e.Graphics.Clear(Color.Transparent);
+                e.Graphics.Clear(Color.FromArgb(64, 64, 64));
                 using (var sf = new StringFormat())
                 using (var brush = new SolidBrush(label.ForeColor))
                 {

--- a/ObservatoryCore/UI/ThemeManager.cs
+++ b/ObservatoryCore/UI/ThemeManager.cs
@@ -16,6 +16,10 @@ namespace Observatory.UI
                 return _instance.Value;
             }
         }
+        private static HashSet<string> _excludedControlNames = new()
+        {
+            "ColourButton",
+        };
         private static readonly Lazy<ThemeManager> _instance = new(() => new ThemeManager());
         private bool _init;
 
@@ -70,6 +74,7 @@ namespace Observatory.UI
             if (control.HasChildren)
                 foreach (Control child in control.Controls)
                 {
+                    if (_excludedControlNames.Contains(child.Name)) continue;
                     RegisterControl(child);
                 }
         }


### PR DESCRIPTION
- Notification title was previously missing; it's back!
- Fixed window and label backgrounds to be correctly/consistently transparent.
- Reduced title size to avoid wrapping. Moved the body text up a few pixels to close the larger gap between title and body.
- Excluded the colour picker button from theming so it always shows the correct colour.
- Widened the Notification font selector in Core settings to allow distinguishing between variants of large font families.

The click-thru bit is only partially working (transparent areas are click-thru).

![image](https://github.com/Xjph/ObservatoryCore/assets/54195004/a8134322-a11e-4d69-b932-59444a187299)

<img width="270" alt="image" src="https://github.com/Xjph/ObservatoryCore/assets/54195004/49967dce-7357-4b2d-ba13-2e4a69d8015c">
