### PR TITLE
[Core] Fix Notification positioning

### DIFF
--- a/ObservatoryCore/UI/NotificationForm.cs
+++ b/ObservatoryCore/UI/NotificationForm.cs
@@ -129,7 +129,7 @@ namespace Observatory.UI
             {
                 _defaultPosition = false;
                 int xLocation = Convert.ToInt32(screenBounds.Width * x);
-                int yLocation = Convert.ToInt32(screenBounds.Height * x);
+                int yLocation = Convert.ToInt32(screenBounds.Height * y);
                 Location = Point.Add(screenBounds.Location, new Size(xLocation, yLocation));
             }
             else


### PR DESCRIPTION
Fixed-position notification positioning was off. Finally figured out why... The XPos arg was used for Y position as well.

A classic 1 character fix...