### PR TITLE
[Core] Some fixes to theming

### DIFF
--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -60,7 +60,7 @@ namespace Observatory.UI
             {
                 ThemeDropdown.Items.Add(theme);
             }
-            ThemeDropdown.SelectedItem = themeManager.CurrentTheme;
+            ThemeDropdown.SelectedItem = "Dark"; // TODO: Set from settings.
         }
 
         private void CoreMenu_SizeChanged(object? sender, EventArgs e)
@@ -291,6 +291,7 @@ namespace Observatory.UI
         private void ThemeDropdown_SelectedIndexChanged(object sender, EventArgs e)
         {
             themeManager.CurrentTheme = ThemeDropdown.SelectedItem.ToString() ?? themeManager.CurrentTheme;
+            // TODO: Save as setting.
         }
     }
 }

--- a/ObservatoryCore/UI/PluginHelper.cs
+++ b/ObservatoryCore/UI/PluginHelper.cs
@@ -52,7 +52,10 @@ namespace Observatory.UI
             if (plugin.PluginUI.PluginUIType == Framework.PluginUI.UIType.Basic)
                 uiPanels.Add(newItem, CreateBasicUI(plugin));
             else if (plugin.PluginUI.PluginUIType == Framework.PluginUI.UIType.Panel)
+            {
                 uiPanels.Add(newItem, (Panel)plugin.PluginUI.UI);
+                ThemeManager.GetInstance.RegisterControl((Panel)plugin.PluginUI.UI);
+            }
         }
 
         private static Panel CreateBasicUI(IObservatoryPlugin plugin)

--- a/ObservatoryCore/UI/ThemeManager.cs
+++ b/ObservatoryCore/UI/ThemeManager.cs
@@ -76,12 +76,12 @@ namespace Observatory.UI
 
             controls.Add(control);
             ApplyTheme(control);
-            if (control.HasChildren)
-                foreach (Control child in control.Controls)
-                {
-                    if (_excludedControlNames.Contains(child.Name)) continue;
-                    RegisterControl(child);
-                }
+            //if (control.HasChildren)
+            //    foreach (Control child in control.Controls)
+            //    {
+            //        if (_excludedControlNames.Contains(child.Name)) continue;
+            //        RegisterControl(child);
+            //    }
         }
 
         // This doesn't inherit from Control? Seriously?
@@ -131,11 +131,11 @@ namespace Observatory.UI
 
         public void DeRegisterControl(Control control)
         { 
-            if (control.HasChildren)
-                foreach (Control child in control.Controls)
-                {
-                    DeRegisterControl(child);
-                }
+            //if (control.HasChildren)
+            //    foreach (Control child in control.Controls)
+            //    {
+            //        DeRegisterControl(child);
+            //    }
             controls.Remove(control); 
         }
 
@@ -156,6 +156,14 @@ namespace Observatory.UI
                     property.SetValue(control, Themes[SelectedTheme][themeControl + "." + property.Name]);
             }
 
+            Control actualControl = control as Control;
+            if (actualControl != null && actualControl.HasChildren)
+            {
+                foreach (Control child in actualControl.Controls)
+                {
+                    ApplyTheme(child);
+                }
+            }
         }
 
         private Dictionary<string, Dictionary<string, Color>> Themes;


### PR DESCRIPTION
Fix a handful of issues with themes and theme switching:

1.  Panel Plugin UIs were not registered, and thus switching themes resulted in ugliness (ie. a partially applied theme; see "before" screenies below). Turns out they are root controls as well, so...
2. When registering controls, now **all** root controls (not just the first) have their theme saved when registered to ensure all Light theme properties are captured. Light theme is now the Manager default (for populating the default light theme on registration) and then the dark theme is applied as last thing after all other initialization. (It remains a TODO to initialize the theme from settings.)
3. Handle menu items properly -- which means saving their default light theme properties when registering the first one, and capturing them as into a list (like we do controls) and iterating that list when the theme is switched.

Before Light (the plugin menu items and much of the panel UI did not get applied correctly): 
![Screenshot 2024-04-02 232021](https://github.com/Xjph/ObservatoryCore/assets/54195004/e37d5fcc-74e3-482b-a342-d27980ccfc09)

Before Dark (notice dark theme is only partially applied to Panel UI): 
![Screenshot 2024-04-02 224633](https://github.com/Xjph/ObservatoryCore/assets/54195004/c8b1c2bc-f4f8-4fc0-bd2b-3f13ea59beaf)

Fixed Light theme w/ Panel plugin:
![Screenshot 2024-04-03 010115](https://github.com/Xjph/ObservatoryCore/assets/54195004/c04e271c-bd88-42c8-a7fd-d5e5baecf9d9)

Fixed Dark theme w/ Panel plugin: 
![Screenshot 2024-04-03 000218](https://github.com/Xjph/ObservatoryCore/assets/54195004/ba89160b-5649-4f1c-892c-d25acf53ce81)
