### PR TITLE
[Core] Make button styles consistent throughout the app

### DIFF
--- a/ObservatoryCore/UI/CoreForm.Designer.cs
+++ b/ObservatoryCore/UI/CoreForm.Designer.cs
@@ -34,6 +34,7 @@
             coreToolStripMenuItem = new ToolStripMenuItem();
             toolStripMenuItem1 = new ToolStripMenuItem();
             CorePanel = new Panel();
+            ButtonAddTheme = new Button();
             ThemeDropdown = new ComboBox();
             ThemeLabel = new Label();
             AudioLabel = new Label();
@@ -77,7 +78,6 @@
             DonateLink = new LinkLabel();
             PopupColour = new ColorDialog();
             OverrideTooltip = new ToolTip(components);
-            ButtonAddTheme = new Button();
             CoreMenu.SuspendLayout();
             CorePanel.SuspendLayout();
             VoiceSettingsPanel.SuspendLayout();
@@ -135,6 +135,18 @@
             CorePanel.Name = "CorePanel";
             CorePanel.Size = new Size(665, 679);
             CorePanel.TabIndex = 1;
+            // 
+            // ButtonAddTheme
+            // 
+            ButtonAddTheme.FlatAppearance.BorderSize = 0;
+            ButtonAddTheme.FlatStyle = FlatStyle.Flat;
+            ButtonAddTheme.Location = new Point(251, 620);
+            ButtonAddTheme.Name = "ButtonAddTheme";
+            ButtonAddTheme.Size = new Size(88, 23);
+            ButtonAddTheme.TabIndex = 11;
+            ButtonAddTheme.Text = "Add Theme";
+            ButtonAddTheme.UseVisualStyleBackColor = true;
+            ButtonAddTheme.Click += ButtonAddTheme_Click;
             // 
             // ThemeDropdown
             // 
@@ -231,6 +243,7 @@
             // 
             // VoiceTestButton
             // 
+            VoiceTestButton.FlatAppearance.BorderSize = 0;
             VoiceTestButton.FlatStyle = FlatStyle.Flat;
             VoiceTestButton.Location = new Point(190, 131);
             VoiceTestButton.Name = "VoiceTestButton";
@@ -348,6 +361,7 @@
             // 
             // TestButton
             // 
+            TestButton.FlatAppearance.BorderSize = 0;
             TestButton.FlatStyle = FlatStyle.Flat;
             TestButton.Location = new Point(190, 152);
             TestButton.Name = "TestButton";
@@ -583,16 +597,6 @@
             DonateLink.TabStop = true;
             DonateLink.Text = "Donate";
             DonateLink.LinkClicked += DonateLink_LinkClicked;
-            // 
-            // ButtonAddTheme
-            // 
-            ButtonAddTheme.Location = new Point(251, 620);
-            ButtonAddTheme.Name = "ButtonAddTheme";
-            ButtonAddTheme.Size = new Size(88, 23);
-            ButtonAddTheme.TabIndex = 11;
-            ButtonAddTheme.Text = "Add Theme";
-            ButtonAddTheme.UseVisualStyleBackColor = true;
-            ButtonAddTheme.Click += ButtonAddTheme_Click;
             // 
             // CoreForm
             // 

--- a/ObservatoryCore/UI/SettingsForm.Designer.cs
+++ b/ObservatoryCore/UI/SettingsForm.Designer.cs
@@ -34,6 +34,8 @@ namespace Observatory.UI
             // PluginSettingsCloseButton
             // 
             PluginSettingsCloseButton.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            PluginSettingsCloseButton.FlatAppearance.BorderSize = 0;
+            PluginSettingsCloseButton.FlatStyle = FlatStyle.Flat;
             PluginSettingsCloseButton.Location = new Point(339, 5);
             PluginSettingsCloseButton.Name = "PluginSettingsCloseButton";
             PluginSettingsCloseButton.Size = new Size(75, 23);

--- a/ObservatoryCore/UI/SettingsForm.cs
+++ b/ObservatoryCore/UI/SettingsForm.cs
@@ -266,8 +266,10 @@ namespace Observatory.UI
                 Text = settingName,
                 Width = Convert.ToInt32(_colWidth * 0.8),
                 Height = 35,
+                FlatStyle = FlatStyle.Flat,
             };
 
+            button.FlatAppearance.BorderSize = 0;
             button.Click += (sender, e) =>
             {
                 action.Invoke();
@@ -414,8 +416,10 @@ namespace Observatory.UI
                 Text = "Browse",
                 Height = 35,
                 Width = _colWidth / 2,
+                FlatStyle = FlatStyle.Flat,
             };
 
+            button.FlatAppearance.BorderSize = 0;
             button.Click += (object? sender, EventArgs e) =>
             {
                 var currentDir = ((FileInfo?)setting.GetValue(_plugin.Settings))?.DirectoryName;


### PR DESCRIPTION
Some core settings buttons and settings window buttons were inconsistent with the cluster of 4 buttons at the bottom of the Core window and below the Plugin list. I took those to be the defacto standard.

Applied the following changes to all inconsistent buttons (some programmatically for generated settings UI and the rest via designer):

```
button.FlatStyle = FlatStyle.Flat;
button.FlatAppearance.BorderSize = 0;
```

The only button I didn't touch was the Colour swatch button -- so if the selected colour is the same as the background for some reason, you can still see it.

Before: 
<img width="907" alt="image" src="https://github.com/Xjph/ObservatoryCore/assets/54195004/9f0fc29f-45d5-4e05-9878-599276a7ab89">

After:
![Screenshot 2024-04-27 224907](https://github.com/Xjph/ObservatoryCore/assets/54195004/2ec8d654-565d-47a1-bc05-7ff80892e141)

