### PR TITLE
[Framework + Core] Add OpenSettings and FocusPlugin actions to Core

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -143,8 +143,7 @@ namespace Observatory.PluginManagement
 
         public void ExecuteOnUIThread(Action action)
         {
-            if (Application.OpenForms.Count > 0)
-                Application.OpenForms[0].Invoke(action);
+            FindCoreForm()?.Invoke(action);
         }
 
         public System.Net.Http.HttpClient HttpClient
@@ -209,7 +208,7 @@ namespace Observatory.PluginManagement
 
         public string GetCurrentThemeName() =>
             ThemeManager.GetInstance.CurrentTheme;
-        
+
         public Dictionary<string, Color> GetCurrentThemeDetails() =>
             ThemeManager.GetInstance.CurrentThemeDetails;
 
@@ -218,10 +217,26 @@ namespace Observatory.PluginManagement
             PluginManager.GetInstance.SaveSettings(plugin);
         }
 
+        public void OpenSettings(IObservatoryPlugin plugin)
+        {
+            ExecuteOnUIThread(() =>
+            {
+                FindCoreForm()?.OpenSettings(plugin);
+            });
+        }
+
         public JournalEventArgs DeserializeEvent(string json, bool replay = false)
         {
             var logMonitor = LogMonitor.GetInstance;
             return logMonitor.DeserializeAndInvoke(json, replay);
+        }
+
+        public void FocusPlugin(string pluginName)
+        {
+            ExecuteOnUIThread(() =>
+            {
+                FindCoreForm()?.FocusPlugin(pluginName);
+            });
         }
 
         internal void Shutdown()
@@ -260,6 +275,18 @@ namespace Observatory.PluginManagement
                 {
                     listView = (PluginListView)control;
                     return listView;
+                }
+            }
+            return null;
+        }
+
+        private CoreForm? FindCoreForm()
+        {
+            foreach (var f in Application.OpenForms)
+            {
+                if (f is CoreForm)
+                {
+                    return (CoreForm)f;
                 }
             }
             return null;

--- a/ObservatoryCore/UI/CoreForm.Plugins.cs
+++ b/ObservatoryCore/UI/CoreForm.Plugins.cs
@@ -148,22 +148,28 @@ namespace Observatory.UI
             return maxWidth + 25;
         }
 
+        // This is public as it is called by PluginCore on behalf of a plugin.
+        public void OpenSettings(IObservatoryPlugin plugin)
+        {
+            if (SettingsForms.ContainsKey(plugin))
+            {
+                SettingsForms[plugin].Activate();
+            }
+            else
+            {
+                SettingsForm settingsForm = new(plugin);
+                SettingsForms.Add(plugin, settingsForm);
+                settingsForm.FormClosed += (_, _) => SettingsForms.Remove(plugin);
+                settingsForm.Show();
+            }
+        }
+
         private void PluginSettingsButton_Click(object sender, EventArgs e)
         {
             if (ListedPlugins != null && PluginList.SelectedItems.Count != 0)
             {
                 var plugin = ListedPlugins[PluginList.SelectedItems[0]];
-                if (SettingsForms.ContainsKey(plugin))
-                {
-                    SettingsForms[plugin].Activate();
-                }
-                else
-                {
-                    SettingsForm settingsForm = new(plugin);
-                    SettingsForms.Add(plugin, settingsForm);
-                    settingsForm.FormClosed += (_, _) => SettingsForms.Remove(plugin);
-                    settingsForm.Show();
-                }
+                OpenSettings(plugin);
             }
         }
 

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -64,6 +64,29 @@ namespace Observatory.UI
             CreatePluginTabs();
         }
 
+        public void FocusPlugin(string pluginShortName)
+        {
+            var pluginItem = FindMenuItemForPlugin(pluginShortName);
+            if (pluginItem != null)
+            {
+                SuspendDrawing(this);
+                ActivatePluginTab(pluginItem);
+                ResumeDrawing(this);
+            }
+        }
+
+        private ToolStripItem? FindMenuItemForPlugin(string pluginShortName)
+        {
+            foreach (ToolStripItem item in CoreMenu.Items)
+            {
+                if (item.Text == pluginShortName)
+                {
+                    return item;
+                }
+            }
+            return null;
+        }
+
         private void CoreMenu_SizeChanged(object? sender, EventArgs e)
         {
             CorePanel.Location = new Point(12 + CoreMenu.Width, 12);
@@ -129,24 +152,29 @@ namespace Observatory.UI
             }
             else
             {
-                foreach (var panel in uiPanels.Where(p => p.Key != e.ClickedItem))
-                {
-                    panel.Value.Visible = false;
-                }
-
-                if (!Controls.Contains(uiPanels[e.ClickedItem]))
-                {
-                    uiPanels[e.ClickedItem].Location = CorePanel.Location;
-                    uiPanels[e.ClickedItem].Size = CorePanel.Size;
-                    uiPanels[e.ClickedItem].BackColor = CorePanel.BackColor;
-                    uiPanels[e.ClickedItem].Parent = CorePanel.Parent;
-                    Controls.Add(uiPanels[e.ClickedItem]);
-                }
-                uiPanels[e.ClickedItem].Visible = true;
-
-                SetClickedItem(e.ClickedItem);
+                ActivatePluginTab(e.ClickedItem);
             }
             ResumeDrawing(this);
+        }
+
+        private void ActivatePluginTab(ToolStripItem item)
+        {
+            foreach (var panel in uiPanels.Where(p => p.Key != item))
+            {
+                panel.Value.Visible = false;
+            }
+
+            if (!Controls.Contains(uiPanels[item]))
+            {
+                uiPanels[item].Location = CorePanel.Location;
+                uiPanels[item].Size = CorePanel.Size;
+                uiPanels[item].BackColor = CorePanel.BackColor;
+                uiPanels[item].Parent = CorePanel.Parent;
+                Controls.Add(uiPanels[item]);
+            }
+            uiPanels[item].Visible = true;
+
+            SetClickedItem(item);
         }
 
         private void SetClickedItem(ToolStripItem item)

--- a/ObservatoryFramework/Interfaces.cs
+++ b/ObservatoryFramework/Interfaces.cs
@@ -287,13 +287,23 @@ namespace Observatory.Framework.Interfaces
         public void SaveSettings(IObservatoryPlugin plugin);
 
         /// <summary>
+        /// Request that Observatory open the setting form for the current plugin
+        /// </summary>
+        public void OpenSettings(IObservatoryPlugin plugin);
+
+        /// <summary>
         /// Deserializes a journal event from JSON into a journal object.
         /// </summary>
         /// <param name="json">JSON string representing a journal event</param>
         /// <param name="replay">(Optional) Replay this event as a current journal entry to all plugins</param>
         /// <returns>Journal object of the json passed in</returns>
         public JournalEventArgs DeserializeEvent(string json, bool replay = false);
-        
+
+        /// <summary>
+        /// Switches focus to the named plugin (if found).
+        /// </summary>
+        /// <param name="pluginName">The short name of the plugin which should be focused.</param>
+        public void FocusPlugin(string pluginName);
     }
 
     /// <summary>

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -1703,6 +1703,11 @@
             Request that Observatory save plugin settings to preserve changes made outside the settings UI.
             </summary>
         </member>
+        <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.OpenSettings(Observatory.Framework.Interfaces.IObservatoryPlugin)">
+            <summary>
+            Request that Observatory open the setting form for the current plugin
+            </summary>
+        </member>
         <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.DeserializeEvent(System.String,System.Boolean)">
             <summary>
             Deserializes a journal event from JSON into a journal object.
@@ -1710,6 +1715,12 @@
             <param name="json">JSON string representing a journal event</param>
             <param name="replay">(Optional) Replay this event as a current journal entry to all plugins</param>
             <returns>Journal object of the json passed in</returns>
+        </member>
+        <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.FocusPlugin(System.String)">
+            <summary>
+            Switches focus to the named plugin (if found).
+            </summary>
+            <param name="pluginName">The short name of the plugin which should be focused.</param>
         </member>
         <member name="T:Observatory.Framework.Interfaces.IObservatoryComparer">
             <summary>


### PR DESCRIPTION
Adds two new actions to IObservatoryCore (and implements them):

OpenSettings: Opens the Settings form for the given plugin (presumably the caller).

FocusPlugin: Switches to the plugin tab matching the given plugin shortname (which may be obtained via NotificationArgs.Sender).