### PR TITLE
[Core] Handle errors in ObservatoryReady() to avoid crashing app

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -315,7 +315,14 @@ namespace Observatory.PluginManagement
 
             foreach (IObservatoryPlugin plugin in workers.Concat<IObservatoryPlugin>(notifiers))
             {
-                plugin.ObservatoryReady();
+                try
+                {
+                    plugin.ObservatoryReady();
+                }
+                catch (Exception ex)
+                {
+                    core.GetPluginErrorLogger(plugin)(ex, "in ObservatoryReady()");
+                }
             }
         }
 


### PR DESCRIPTION
New feature, new crash opportunities? Let's try minimize that. :D

Used standard error logging mechanisms.