### PR TITLE
feat(core,herald): Unify volume settings; make overrides dynamic

### DIFF
--- a/ObservatoryCore/App.config
+++ b/ObservatoryCore/App.config
@@ -91,6 +91,9 @@
             <setting name="ExportFormat" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="AudioVolume" serializeAs="String">
+                <value>0.75</value>
+            </setting>
         </Observatory.Properties.Core>
     </userSettings>
 </configuration>

--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -7,12 +7,10 @@ using Observatory.Utils;
 
 namespace Observatory.PluginManagement
 {
-    public class PluginCore(bool OverridePopup = false, bool OverrideAudio = false) : IObservatoryCore
+    public class PluginCore() : IObservatoryCore
     {
         private readonly NativeVoice NativeVoice = new();
         private readonly NativePopup NativePopup = new();
-        private readonly bool OverridePopup = OverridePopup;
-        private readonly bool OverrideAudio = OverrideAudio;
         private readonly AudioHandler AudioHandler = new();
 
         public string Version => System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "0";
@@ -52,13 +50,16 @@ namespace Observatory.PluginManagement
                     handler?.Invoke(this, notificationArgs);
                 }
 #endif
-
-                if (!OverridePopup && Properties.Core.Default.NativeNotify && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVisual))
+                if (!PluginManager.GetInstance.HasPopupOverrideNotifiers
+                    && Properties.Core.Default.NativeNotify 
+                    && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVisual))
                 {
                     guid = NativePopup.InvokeNativeNotification(notificationArgs);
                 }
 
-                if (!OverrideAudio && Properties.Core.Default.VoiceNotify && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
+                if (!PluginManager.GetInstance.HasAudioOverrideNotifiers
+                    && Properties.Core.Default.VoiceNotify
+                    && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
                 {
                     NativeVoice.EnqueueAndAnnounce(notificationArgs);
                 }

--- a/ObservatoryCore/PluginManagement/PluginEventHandler.cs
+++ b/ObservatoryCore/PluginManagement/PluginEventHandler.cs
@@ -11,7 +11,7 @@ namespace Observatory.PluginManagement
     {
         private IEnumerable<IObservatoryWorker> observatoryWorkers;
         private IEnumerable<IObservatoryNotifier> observatoryNotifiers;
-        private HashSet<IObservatoryPlugin> disabledPlugins;
+        private readonly HashSet<IObservatoryPlugin> disabledPlugins;
         private List<(string error, string detail)> errorList;
         private System.Timers.Timer timer;
 
@@ -24,6 +24,8 @@ namespace Observatory.PluginManagement
 
             InitializeTimer();
         }
+
+        public HashSet<IObservatoryPlugin> DisabledPlugins {  get => disabledPlugins; }
 
         private void InitializeTimer()
         {

--- a/ObservatoryCore/Properties/Core.Designer.cs
+++ b/ObservatoryCore/Properties/Core.Designer.cs
@@ -12,7 +12,7 @@ namespace Observatory.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.10.0.0")]
     internal sealed partial class Core : global::System.Configuration.ApplicationSettingsBase {
         
         private static Core defaultInstance = ((Core)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Core())));
@@ -367,6 +367,18 @@ namespace Observatory.Properties {
             }
             set {
                 this["ExportFormat"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0.75")]
+        public float AudioVolume {
+            get {
+                return ((float)(this["AudioVolume"]));
+            }
+            set {
+                this["AudioVolume"] = value;
             }
         }
     }

--- a/ObservatoryCore/Properties/Core.settings
+++ b/ObservatoryCore/Properties/Core.settings
@@ -89,5 +89,8 @@
     <Setting Name="ExportFormat" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="AudioVolume" Type="System.Single" Scope="User">
+      <Value Profile="(Default)">0.75</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/ObservatoryCore/UI/CoreForm.Designer.cs
+++ b/ObservatoryCore/UI/CoreForm.Designer.cs
@@ -48,8 +48,8 @@
             VersionColumn = new ColumnHeader();
             StatusColumn = new ColumnHeader();
             PluginListButtonsLayoutPanel = new FlowLayoutPanel();
-            PluginFolderButton = new Button();
             PluginSettingsButton = new Button();
+            PluginFolderButton = new Button();
             CoreSettingsLayoutPanel = new FlowLayoutPanel();
             PopupSettingsPanel = new Panel();
             DurationSpinner = new NumericUpDown();
@@ -71,24 +71,24 @@
             PopupDisabledLabel = new Label();
             VoiceSettingsPanel = new Panel();
             VoiceSpeedSlider = new TrackBar();
-            VoiceVolumeSlider = new TrackBar();
             VoiceLabel = new Label();
             VoiceTestButton = new Button();
             VoiceSpeedLabel = new Label();
             AudioLabel = new Label();
             VoiceDropdown = new ComboBox();
             VoiceCheckbox = new CheckBox();
-            VoiceVolumeLabel = new Label();
             VoiceDisabledPanel = new Panel();
             VoiceDisabledLabel = new Label();
             CoreSettingsPanel = new Panel();
             ExportFormatLabel = new Label();
+            AudioVolumeSlider = new TrackBar();
             ExportFormatDropdown = new ComboBox();
             CoreSettingsLabel = new Label();
             StartReadallCheckbox = new CheckBox();
             StartMonitorCheckbox = new CheckBox();
             LabelJournal = new Label();
             ThemeLabel = new Label();
+            VoiceVolumeLabel = new Label();
             LabelJournalPath = new Label();
             ThemeDropdown = new ComboBox();
             ButtonAddTheme = new Button();
@@ -107,9 +107,9 @@
             PopupDisabledPanel.SuspendLayout();
             VoiceSettingsPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)VoiceSpeedSlider).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)VoiceVolumeSlider).BeginInit();
             VoiceDisabledPanel.SuspendLayout();
             CoreSettingsPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)AudioVolumeSlider).BeginInit();
             SuspendLayout();
             // 
             // ReadAllButton
@@ -235,6 +235,7 @@
             // 
             CoreSplitter.Panel2.BackColor = SystemColors.Control;
             CoreSplitter.Panel2.Controls.Add(CoreSettingsLayoutPanel);
+            CoreSplitter.Panel2.Padding = new Padding(3);
             CoreSplitter.Size = new Size(819, 817);
             CoreSplitter.SplitterDistance = 179;
             CoreSplitter.TabIndex = 16;
@@ -295,40 +296,39 @@
             // 
             // PluginListButtonsLayoutPanel
             // 
-            PluginListButtonsLayoutPanel.Controls.Add(PluginFolderButton);
             PluginListButtonsLayoutPanel.Controls.Add(PluginSettingsButton);
+            PluginListButtonsLayoutPanel.Controls.Add(PluginFolderButton);
             PluginListButtonsLayoutPanel.Dock = DockStyle.Fill;
-            PluginListButtonsLayoutPanel.FlowDirection = FlowDirection.RightToLeft;
             PluginListButtonsLayoutPanel.Location = new Point(3, 142);
             PluginListButtonsLayoutPanel.Name = "PluginListButtonsLayoutPanel";
             PluginListButtonsLayoutPanel.Size = new Size(813, 34);
             PluginListButtonsLayoutPanel.TabIndex = 9;
-            // 
-            // PluginFolderButton
-            // 
-            PluginFolderButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            PluginFolderButton.FlatAppearance.BorderSize = 0;
-            PluginFolderButton.FlatStyle = FlatStyle.Flat;
-            PluginFolderButton.Location = new Point(680, 3);
-            PluginFolderButton.Name = "PluginFolderButton";
-            PluginFolderButton.Size = new Size(130, 23);
-            PluginFolderButton.TabIndex = 10;
-            PluginFolderButton.Text = "Open Plugin Folder";
-            PluginFolderButton.UseVisualStyleBackColor = false;
-            PluginFolderButton.Click += PluginFolderButton_Click;
             // 
             // PluginSettingsButton
             // 
             PluginSettingsButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             PluginSettingsButton.FlatAppearance.BorderSize = 0;
             PluginSettingsButton.FlatStyle = FlatStyle.Flat;
-            PluginSettingsButton.Location = new Point(554, 3);
+            PluginSettingsButton.Location = new Point(3, 3);
             PluginSettingsButton.Name = "PluginSettingsButton";
             PluginSettingsButton.Size = new Size(120, 23);
             PluginSettingsButton.TabIndex = 11;
             PluginSettingsButton.Text = "Plugin Settings";
             PluginSettingsButton.UseVisualStyleBackColor = false;
             PluginSettingsButton.Click += PluginSettingsButton_Click;
+            // 
+            // PluginFolderButton
+            // 
+            PluginFolderButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            PluginFolderButton.FlatAppearance.BorderSize = 0;
+            PluginFolderButton.FlatStyle = FlatStyle.Flat;
+            PluginFolderButton.Location = new Point(129, 3);
+            PluginFolderButton.Name = "PluginFolderButton";
+            PluginFolderButton.Size = new Size(130, 23);
+            PluginFolderButton.TabIndex = 10;
+            PluginFolderButton.Text = "Open Plugins Folder";
+            PluginFolderButton.UseVisualStyleBackColor = false;
+            PluginFolderButton.Click += PluginFolderButton_Click;
             // 
             // CoreSettingsLayoutPanel
             // 
@@ -337,9 +337,9 @@
             CoreSettingsLayoutPanel.Controls.Add(VoiceSettingsPanel);
             CoreSettingsLayoutPanel.Controls.Add(CoreSettingsPanel);
             CoreSettingsLayoutPanel.Dock = DockStyle.Fill;
-            CoreSettingsLayoutPanel.Location = new Point(0, 0);
+            CoreSettingsLayoutPanel.Location = new Point(3, 3);
             CoreSettingsLayoutPanel.Name = "CoreSettingsLayoutPanel";
-            CoreSettingsLayoutPanel.Size = new Size(819, 634);
+            CoreSettingsLayoutPanel.Size = new Size(813, 628);
             CoreSettingsLayoutPanel.TabIndex = 34;
             // 
             // PopupSettingsPanel
@@ -550,14 +550,12 @@
             VoiceSettingsPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             VoiceSettingsPanel.BorderStyle = BorderStyle.FixedSingle;
             VoiceSettingsPanel.Controls.Add(VoiceSpeedSlider);
-            VoiceSettingsPanel.Controls.Add(VoiceVolumeSlider);
             VoiceSettingsPanel.Controls.Add(VoiceLabel);
             VoiceSettingsPanel.Controls.Add(VoiceTestButton);
             VoiceSettingsPanel.Controls.Add(VoiceSpeedLabel);
             VoiceSettingsPanel.Controls.Add(AudioLabel);
             VoiceSettingsPanel.Controls.Add(VoiceDropdown);
             VoiceSettingsPanel.Controls.Add(VoiceCheckbox);
-            VoiceSettingsPanel.Controls.Add(VoiceVolumeLabel);
             VoiceSettingsPanel.Controls.Add(VoiceDisabledPanel);
             VoiceSettingsPanel.Location = new Point(3, 239);
             VoiceSettingsPanel.Name = "VoiceSettingsPanel";
@@ -566,7 +564,7 @@
             // 
             // VoiceSpeedSlider
             // 
-            VoiceSpeedSlider.Location = new Point(109, 70);
+            VoiceSpeedSlider.Location = new Point(109, 20);
             VoiceSpeedSlider.Minimum = 1;
             VoiceSpeedSlider.Name = "VoiceSpeedSlider";
             VoiceSpeedSlider.Size = new Size(120, 45);
@@ -575,23 +573,10 @@
             VoiceSpeedSlider.Value = 10;
             VoiceSpeedSlider.Scroll += VoiceSpeedSlider_Scroll;
             // 
-            // VoiceVolumeSlider
-            // 
-            VoiceVolumeSlider.LargeChange = 10;
-            VoiceVolumeSlider.Location = new Point(108, 20);
-            VoiceVolumeSlider.Maximum = 100;
-            VoiceVolumeSlider.Name = "VoiceVolumeSlider";
-            VoiceVolumeSlider.Size = new Size(121, 45);
-            VoiceVolumeSlider.TabIndex = 14;
-            VoiceVolumeSlider.TickFrequency = 10;
-            VoiceVolumeSlider.TickStyle = TickStyle.Both;
-            VoiceVolumeSlider.Value = 100;
-            VoiceVolumeSlider.Scroll += VoiceVolumeSlider_Scroll;
-            // 
             // VoiceLabel
             // 
             VoiceLabel.AutoSize = true;
-            VoiceLabel.Location = new Point(65, 124);
+            VoiceLabel.Location = new Point(65, 74);
             VoiceLabel.Name = "VoiceLabel";
             VoiceLabel.Size = new Size(38, 15);
             VoiceLabel.TabIndex = 4;
@@ -602,7 +587,7 @@
             // 
             VoiceTestButton.FlatAppearance.BorderSize = 0;
             VoiceTestButton.FlatStyle = FlatStyle.Flat;
-            VoiceTestButton.Location = new Point(178, 150);
+            VoiceTestButton.Location = new Point(178, 100);
             VoiceTestButton.Name = "VoiceTestButton";
             VoiceTestButton.Size = new Size(51, 23);
             VoiceTestButton.TabIndex = 13;
@@ -613,7 +598,7 @@
             // VoiceSpeedLabel
             // 
             VoiceSpeedLabel.AutoSize = true;
-            VoiceSpeedLabel.Location = new Point(61, 82);
+            VoiceSpeedLabel.Location = new Point(61, 32);
             VoiceSpeedLabel.Name = "VoiceSpeedLabel";
             VoiceSpeedLabel.Size = new Size(42, 15);
             VoiceSpeedLabel.TabIndex = 1;
@@ -633,7 +618,7 @@
             // 
             VoiceDropdown.DropDownStyle = ComboBoxStyle.DropDownList;
             VoiceDropdown.FormattingEnabled = true;
-            VoiceDropdown.Location = new Point(109, 121);
+            VoiceDropdown.Location = new Point(109, 71);
             VoiceDropdown.Name = "VoiceDropdown";
             VoiceDropdown.Size = new Size(121, 23);
             VoiceDropdown.TabIndex = 5;
@@ -642,23 +627,13 @@
             // VoiceCheckbox
             // 
             VoiceCheckbox.AutoSize = true;
-            VoiceCheckbox.Location = new Point(108, 153);
+            VoiceCheckbox.Location = new Point(108, 103);
             VoiceCheckbox.Name = "VoiceCheckbox";
             VoiceCheckbox.Size = new Size(68, 19);
             VoiceCheckbox.TabIndex = 11;
             VoiceCheckbox.Text = "Enabled";
             VoiceCheckbox.UseVisualStyleBackColor = true;
             VoiceCheckbox.CheckedChanged += VoiceCheckbox_CheckedChanged;
-            // 
-            // VoiceVolumeLabel
-            // 
-            VoiceVolumeLabel.AutoSize = true;
-            VoiceVolumeLabel.Location = new Point(52, 31);
-            VoiceVolumeLabel.Name = "VoiceVolumeLabel";
-            VoiceVolumeLabel.Size = new Size(50, 15);
-            VoiceVolumeLabel.TabIndex = 0;
-            VoiceVolumeLabel.Text = "Volume:";
-            VoiceVolumeLabel.TextAlign = ContentAlignment.MiddleRight;
             // 
             // VoiceDisabledPanel
             // 
@@ -685,12 +660,14 @@
             CoreSettingsPanel.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             CoreSettingsPanel.BorderStyle = BorderStyle.FixedSingle;
             CoreSettingsPanel.Controls.Add(ExportFormatLabel);
+            CoreSettingsPanel.Controls.Add(AudioVolumeSlider);
             CoreSettingsPanel.Controls.Add(ExportFormatDropdown);
             CoreSettingsPanel.Controls.Add(CoreSettingsLabel);
             CoreSettingsPanel.Controls.Add(StartReadallCheckbox);
             CoreSettingsPanel.Controls.Add(StartMonitorCheckbox);
             CoreSettingsPanel.Controls.Add(LabelJournal);
             CoreSettingsPanel.Controls.Add(ThemeLabel);
+            CoreSettingsPanel.Controls.Add(VoiceVolumeLabel);
             CoreSettingsPanel.Controls.Add(LabelJournalPath);
             CoreSettingsPanel.Controls.Add(ThemeDropdown);
             CoreSettingsPanel.Controls.Add(ButtonAddTheme);
@@ -708,6 +685,19 @@
             ExportFormatLabel.Size = new Size(85, 15);
             ExportFormatLabel.TabIndex = 35;
             ExportFormatLabel.Text = "Export Format:";
+            // 
+            // AudioVolumeSlider
+            // 
+            AudioVolumeSlider.LargeChange = 10;
+            AudioVolumeSlider.Location = new Point(121, 112);
+            AudioVolumeSlider.Maximum = 100;
+            AudioVolumeSlider.Name = "AudioVolumeSlider";
+            AudioVolumeSlider.Size = new Size(214, 45);
+            AudioVolumeSlider.TabIndex = 14;
+            AudioVolumeSlider.TickFrequency = 10;
+            AudioVolumeSlider.TickStyle = TickStyle.Both;
+            AudioVolumeSlider.Value = 100;
+            AudioVolumeSlider.Scroll += AudioVolumeSlider_Scroll;
             // 
             // ExportFormatDropdown
             // 
@@ -732,7 +722,7 @@
             // StartReadallCheckbox
             // 
             StartReadallCheckbox.AutoSize = true;
-            StartReadallCheckbox.Location = new Point(121, 137);
+            StartReadallCheckbox.Location = new Point(121, 183);
             StartReadallCheckbox.Name = "StartReadallCheckbox";
             StartReadallCheckbox.Size = new Size(130, 19);
             StartReadallCheckbox.TabIndex = 15;
@@ -743,7 +733,7 @@
             // StartMonitorCheckbox
             // 
             StartMonitorCheckbox.AutoSize = true;
-            StartMonitorCheckbox.Location = new Point(121, 112);
+            StartMonitorCheckbox.Location = new Point(121, 158);
             StartMonitorCheckbox.Name = "StartMonitorCheckbox";
             StartMonitorCheckbox.Size = new Size(157, 19);
             StartMonitorCheckbox.TabIndex = 14;
@@ -769,6 +759,16 @@
             ThemeLabel.TabIndex = 9;
             ThemeLabel.Text = "Theme:";
             ThemeLabel.TextAlign = ContentAlignment.MiddleCenter;
+            // 
+            // VoiceVolumeLabel
+            // 
+            VoiceVolumeLabel.AutoSize = true;
+            VoiceVolumeLabel.Location = new Point(65, 123);
+            VoiceVolumeLabel.Name = "VoiceVolumeLabel";
+            VoiceVolumeLabel.Size = new Size(50, 15);
+            VoiceVolumeLabel.TabIndex = 0;
+            VoiceVolumeLabel.Text = "Volume:";
+            VoiceVolumeLabel.TextAlign = ContentAlignment.MiddleRight;
             // 
             // LabelJournalPath
             // 
@@ -841,11 +841,11 @@
             VoiceSettingsPanel.ResumeLayout(false);
             VoiceSettingsPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)VoiceSpeedSlider).EndInit();
-            ((System.ComponentModel.ISupportInitialize)VoiceVolumeSlider).EndInit();
             VoiceDisabledPanel.ResumeLayout(false);
             VoiceDisabledPanel.PerformLayout();
             CoreSettingsPanel.ResumeLayout(false);
             CoreSettingsPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)AudioVolumeSlider).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -892,7 +892,7 @@
         private Label PopupLabel;
         private Panel VoiceSettingsPanel;
         private TrackBar VoiceSpeedSlider;
-        private TrackBar VoiceVolumeSlider;
+        private TrackBar AudioVolumeSlider;
         private Button VoiceTestButton;
         private CheckBox VoiceCheckbox;
         private ComboBox VoiceDropdown;

--- a/ObservatoryCore/UI/CoreForm.Settings.cs
+++ b/ObservatoryCore/UI/CoreForm.Settings.cs
@@ -53,9 +53,10 @@ namespace Observatory.UI
             SettingsManager.Save();
         }
 
-        private void VoiceVolumeSlider_Scroll(object _, EventArgs e)
+        private void AudioVolumeSlider_Scroll(object _, EventArgs e)
         {
-            Properties.Core.Default.VoiceVolume = VoiceVolumeSlider.Value;
+            Properties.Core.Default.VoiceVolume = Math.Clamp(AudioVolumeSlider.Value, 0, 100);
+            Properties.Core.Default.AudioVolume = Math.Clamp(AudioVolumeSlider.Value / 100.0f, 0.0f, 1.0f);
             SettingsManager.Save();
         }
 
@@ -104,7 +105,7 @@ namespace Observatory.UI
             TryLoadSetting(DurationSpinner, "Value", (decimal)Math.Clamp(settings.NativeNotifyTimeout, 100, 60000));
             TryLoadSetting(ColourButton, "BackColor", Color.FromArgb((int)settings.NativeNotifyColour));
             TryLoadSetting(PopupCheckbox, "Checked", settings.NativeNotify);
-            TryLoadSetting(VoiceVolumeSlider, "Value", Math.Clamp(settings.VoiceVolume, 0, 100));
+            TryLoadSetting(AudioVolumeSlider, "Value", Math.Clamp(settings.VoiceVolume, 0, 100)); // Also controls AudioVolume setting
             TryLoadSetting(VoiceSpeedSlider, "Value", Math.Clamp(settings.VoiceRate, 1, 10));
             TryLoadSetting(VoiceDropdown, "SelectedItem", settings.VoiceSelected);
             TryLoadSetting(VoiceCheckbox, "Checked", settings.VoiceNotify);
@@ -116,7 +117,6 @@ namespace Observatory.UI
 #if PROTON
             VoiceCheckbox.Checked = false;
             VoiceCheckbox.Enabled = false;
-            VoiceVolumeSlider.Enabled = false;
             VoiceSpeedSlider.Enabled = false;
             VoiceDropdown.Enabled = false;
             VoiceTestButton.Enabled = false;

--- a/ObservatoryCore/Utils/AudioHandler.cs
+++ b/ObservatoryCore/Utils/AudioHandler.cs
@@ -40,6 +40,7 @@ namespace Observatory.Utils
                 {
                     output.Init(file);
                     output.Play();
+                    output.Volume = Properties.Core.Default.AudioVolume;
 
                     while (output.PlaybackState == PlaybackState.Playing)
                     {

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -1701,6 +1701,13 @@
             </summary>
             <param name="control">UI Control object or ToolStripMenuItem</param>
         </member>
+        <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.RegisterControl(System.Object,System.Func{System.Object,System.Boolean})">
+            <summary>
+            Register a UI control for themeing and provide a delegate to selectively theme it and its child controls.
+            </summary>
+            <param name="control">UI Control object or ToolStripMenuItem</param>
+            <param name="applyTheme">Function which accepts a control or ToolStripMenuItem and returns true or false to indicate whether it should be themed.</param>
+        </member>
         <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.UnregisterControl(System.Object)">
             <summary>
             Remove a UI control from themeing.

--- a/ObservatoryHerald/HeraldNotifier.cs
+++ b/ObservatoryHerald/HeraldNotifier.cs
@@ -19,8 +19,6 @@ namespace Observatory.Herald
             {
                 SelectedVoice = "American - Christopher",
                 SelectedRate = "Default",
-                Volume = 75,
-                Enabled = false,
                 ApiEndpoint = "https://api.observatory.xjph.net/AzureVoice",
                 CacheSize = 100
             };
@@ -47,7 +45,6 @@ namespace Observatory.Herald
                 if (string.IsNullOrWhiteSpace(savedSettings.SelectedRate))
                 {
                     heraldSettings.SelectedVoice = savedSettings.SelectedVoice;
-                    heraldSettings.Enabled = savedSettings.Enabled;
                 }
                 else
                 {
@@ -75,21 +72,19 @@ namespace Observatory.Herald
                 }, 
                 GetAzureNameFromSetting(heraldSettings.SelectedVoice),
                 GetAzureStyleNameFromSetting(heraldSettings.SelectedVoice),
-                heraldSettings.Rate[heraldSettings.SelectedRate].ToString(),
-                heraldSettings.Volume);
+                heraldSettings.Rate[heraldSettings.SelectedRate].ToString());
         }
 
         public void OnNotificationEvent(NotificationArgs notificationEventArgs)
         {
             if (Core.IsLogMonitorBatchReading) return;
 
-            if (heraldSettings.Enabled && notificationEventArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
+            if (notificationEventArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
                 heraldSpeech.Enqueue(
                     notificationEventArgs, 
                     GetAzureNameFromSetting(heraldSettings.SelectedVoice),
                     GetAzureStyleNameFromSetting(heraldSettings.SelectedVoice),
-                    heraldSettings.Rate[heraldSettings.SelectedRate].ToString(), 
-                    heraldSettings.Volume);
+                    heraldSettings.Rate[heraldSettings.SelectedRate].ToString());
         }
 
         private string GetAzureNameFromSetting(string settingName)

--- a/ObservatoryHerald/HeraldQueue.cs
+++ b/ObservatoryHerald/HeraldQueue.cs
@@ -11,7 +11,6 @@ namespace Observatory.Herald
         private string voice;
         private string style;
         private string rate;
-        private byte volume;
         private SpeechRequestManager speechManager;
         private Action<Exception, String> ErrorLogger;
         private IObservatoryCore core;
@@ -26,17 +25,11 @@ namespace Observatory.Herald
         }
 
 
-        internal void Enqueue(NotificationArgs notification, string selectedVoice, string selectedStyle = "", string selectedRate = "", int volume = 75)
+        internal void Enqueue(NotificationArgs notification, string selectedVoice, string selectedStyle = "", string selectedRate = "")
         {
             voice = selectedVoice;
             style = selectedStyle;
             rate = selectedRate;
-            // Ignore invalid values; assume default.
-            volume = volume >= 0 && volume <= 100 ? volume : 75;
-
-            // Volume is perceived logarithmically, convert to exponential curve
-            // to make perceived volume more in line with value set.
-            this.volume = ((byte)System.Math.Floor(System.Math.Pow(volume / 100.0, 2.0) * 100));
 
             Debug.WriteLine("Attempting to de-dupe notification titles against '{0}': '{1}'",
                 notification.Title.Trim().ToLower(),

--- a/ObservatoryHerald/HeraldSettings.cs
+++ b/ObservatoryHerald/HeraldSettings.cs
@@ -30,20 +30,13 @@ namespace Observatory.Herald
         [SettingIgnore]
         public string SelectedRate { get; set; }
 
-        [SettingDisplayName("Volume")]
-        [SettingNumericUseSlider, SettingNumericBounds(0,100,1)]
-        public int Volume { get; set;}
+        [SettingDisplayName("Cache Size (MB): ")]
+        public int CacheSize { get; set; }
 
         [System.Text.Json.Serialization.JsonIgnore]
         public Action Test { get; internal set; }
 
-        [SettingDisplayName("Enabled")]
-        public bool Enabled { get; set; }
-
         [SettingIgnore]
         public string ApiEndpoint { get; set; }
-
-        [SettingDisplayName("Cache Size (MB): ")]
-        public int CacheSize { get; set; }
     }
 }


### PR DESCRIPTION
Previously, there was a large volume of volume controls -- which didn't all work:
* Herald/Plugin-provided audio volume doesn't work. Herald had a volume control but it was broken when the audio subsystem was overhauled.
* Native voice volume control worked -- only for native voice.

So now we have 1 volume control to rule them all, now located in core settings, not native voice settings (so always visible/available), which controls ALL audio levels (plugin-provided and native audio). Thus, the Volume setting in Herald is removed.

Of course, to test control of native voice volume, I needed to disable Herald -- which previously required deleting the dll from the plugins folder and restarting the app. That was too much work and doesn't make sense now with the checkboxes in the plugin list to enable/disable plugins. So now, if you toggle Herald's checkbox, it will *dynamically* enable/disable native voice function AND hide/show the settings. No deleting of dlls. No restarting the app!

One last tweak: I moved the plugin settings and plugins folder buttons below the plugin list to be on the left side rather than the right side to locate them closer to where you'd select a plugin (useful for wide/landscape windows).

![image](https://github.com/Xjph/ObservatoryCore/assets/54195004/78348ccd-7f9e-4cfe-a27e-9efa42a43666)
