### PR TITLE
feat: [Explorer] Add a few new convenience functions and constants

### DIFF
--- a/ObservatoryExplorer/CustomCriteriaManager.cs
+++ b/ObservatoryExplorer/CustomCriteriaManager.cs
@@ -142,16 +142,30 @@ namespace Observatory.Explorer
 
             #region Convenience Functions
 
+            // Body type related functions and tests
+
             //Rings - has > 0 belts
             LuaState.DoString(@"
                 function hasBelts (ring_list)
                     return _hasRingsFiltered(ring_list, 'Belt')
                 end");
 
+            //Body name represents a belt
+            LuaState.DoString(@"
+                function isBelt (body_name)
+                    return body_name ~= nil and string.find(body_name, 'Belt')
+                end");
+
             //Rings - has > 0 proper rings
             LuaState.DoString(@"
                 function hasRings (ring_list)
                     return _hasRingsFiltered(ring_list, 'Ring')
+                end");
+
+            //Body name represents a ring
+            LuaState.DoString(@"
+                function isRing (body_name)
+                    return body_name ~= nil and string.find(body_name, 'Ring')
                 end");
 
             LuaState.DoString(@"
@@ -161,8 +175,15 @@ namespace Observatory.Explorer
 
             LuaState.DoString(@"
                 function isPlanet (scan)
-                    return scan.PlanetClass ~= nil
+                    return scan.PlanetClass ~= nil and scan.PlanetClass ~= 'Barycentre'
                 end");
+
+            LuaState.DoString(@"
+                function isBarycentre (scan)
+                    return scan.PlanetClass ~= nil and scan.PlanetClass == 'Barycentre'
+                end");
+
+            // Atmosphere checks
 
             LuaState.DoString(@"
                 function hasAtmosphere (scan)
@@ -172,6 +193,55 @@ namespace Observatory.Explorer
             LuaState.DoString(@"
                 function hasLandableAtmosphere (scan)
                     return scan.Landable and scan.AtmosphereComposition ~= nil
+                end");
+
+            // Common unit conversion functions and related constants
+
+            // Since LUA has no 'const' keyword, using a metatable as recommended by this:
+            // https://andrejs-cainikovs.blogspot.com/2009/05/lua-constants.html
+            LuaState.DoString(@"
+                function protect(tbl)
+                    return setmetatable({}, {
+                        __index = tbl,
+                        __newindex = function(t, key, value)
+                            error(""attempting to change constant "" ..
+                                   tostring(key) .. "" to "" .. tostring(value), 2)
+                        end
+                    })
+                end
+
+                const = {
+                    SPEED_OF_LIGHT_mps = 299792458,
+                    GRAVITY_mps2 = 9.81,
+                    ATM_PRESSURE_Pa = 101325,
+                    DAY_s = 86400
+                }
+                const = protect(const)
+            ");
+
+            LuaState.DoString(@"
+                function distanceAsLs (value_in_m)
+                    return value_in_m / const.SPEED_OF_LIGHT_mps
+                end");
+
+            LuaState.DoString(@"
+                function distanceAsKm (value_in_m)
+                    return value_in_m / 1000
+                end");
+
+            LuaState.DoString(@"
+                function gravityAsG (value_in_mps2)
+                    return value_in_mps2 / const.GRAVITY_mps2
+                end");
+
+            LuaState.DoString(@"
+                function pressureAsAtm (value_in_pa)
+                    return value_in_pa / const.ATM_PRESSURE_Pa
+                end");
+
+            LuaState.DoString(@"
+                function periodAsDay (value_in_s)
+                    return value_in_s / const.DAY_s
                 end");
 
             #endregion

--- a/ObservatoryExplorer/CustomCriteriaManager.cs
+++ b/ObservatoryExplorer/CustomCriteriaManager.cs
@@ -214,7 +214,8 @@ namespace Observatory.Explorer
                     SPEED_OF_LIGHT_mps = 299792458,
                     GRAVITY_mps2 = 9.81,
                     ATM_PRESSURE_Pa = 101325,
-                    DAY_s = 86400
+                    DAY_s = 86400,
+                    HOUR_s = 3600,
                 }
                 const = protect(const)
             ");
@@ -242,6 +243,11 @@ namespace Observatory.Explorer
             LuaState.DoString(@"
                 function periodAsDay (value_in_s)
                     return value_in_s / const.DAY_s
+                end");
+
+            LuaState.DoString(@"
+                function periodAsHour (value_in_s)
+                    return value_in_s / const.HOUR_s
                 end");
 
             #endregion
@@ -458,13 +464,13 @@ namespace Observatory.Explorer
                     case "criteria":
                     case "complex":
                         string debugLabel;
-                        if (annotationRaw.Contains(' '))
-                        {
-                            debugLabel = string.Join(' ', annotationRaw.Split(' ')[1..]);
-                        }
-                        else if (annotationRaw.ToLower().StartsWith("criteria="))
+                        if (annotationRaw.ToLower().StartsWith("criteria="))
                         {
                             debugLabel = annotationRaw[9..];
+                        }
+                        else if (annotationRaw.Contains(' '))
+                        {
+                            debugLabel = string.Join(' ', annotationRaw.Split(' ')[1..]);
                         }
                         else
                         {
@@ -504,9 +510,9 @@ namespace Observatory.Explorer
         private string GetUniqueDescription(string functionName, string scriptDescription)
         {
             string uniqueDescription = functionName;
-            if (scriptDescription.ToLower().StartsWith("criteria="))
+            if (!string.IsNullOrWhiteSpace(scriptDescription) && scriptDescription != functionName)
             {
-                uniqueDescription += scriptDescription.Replace("criteria=", "=", StringComparison.CurrentCultureIgnoreCase);
+                uniqueDescription += '=' + scriptDescription;
             }
             return uniqueDescription;
         }

--- a/ObservatoryExplorer/CustomCriteriaManager.cs
+++ b/ObservatoryExplorer/CustomCriteriaManager.cs
@@ -480,9 +480,9 @@ namespace Observatory.Explorer
                         return true;
                     default:
                         string simpleDescription;
-                        if (line.ToLower().StartsWith("---@simple "))
+                        if (annotationRaw.ToLower().StartsWith("simple "))
                         {
-                            simpleDescription = annotationRaw[11..];
+                            simpleDescription = annotationRaw[7..];
                         }
                         else
                         {


### PR DESCRIPTION
New convenience functions for use in Lua custom criteria.

Interrogation helpers:
* `isBelt(body_name)`
* `isRing(body_name)`
* `isBarycentre(scan)`

Also updated the existing `isPlanet(scan)`function to exclude barycentres.

Conversion helpers:
* `distanceAsLs(value_in_m)`
* `distanceAsKm(value_in_m)`
* `gravityAsG(value_in_mps2)`
* `pressureAsAtm(value_in_pa)`
* `periodAsDay(value_in_s)`
* `periodAsHour(value_in_s)`

There are also new globally available constants related to the unit conversion functions, above:

* `const.SPEED_OF_LIGHT_mps` - the speed of light expressed in meters per second, aka, the constant `c` or 1 Ls.
* `const.GRAVITY_mps2` the acceleration due to gravity expressed in meters per second squared, or 1g.
* `const.ATM_PRESSURE_Pa` the pressure of 1 atm expressed in pascals.
* `const.DAY_s` the number of seconds in a day (assumed to be 24 hours).
* `const.HOUR_s` the number of seconds in an hour (assumed to be 60 minutes).

Also fixed up the debugging labels for functions which were recently broken.