### PR TITLE
fix: [Core] Use all visible plugins for drawing tabs

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -34,6 +34,12 @@ namespace Observatory.PluginManagement
         private readonly PluginCore core;
         private readonly PluginEventHandler pluginHandler;
         
+        // Intended for rendering Tabs. Includes Disabled plugins.
+        public List<(IObservatoryWorker plugin, PluginStatus signed)> AllUIPlugins
+        {
+            get => _workerPlugins.Where(p => p.plugin.PluginUI.PluginUIType != Framework.PluginUI.UIType.None).ToList();
+        }
+
         public List<(IObservatoryWorker plugin, PluginStatus signed)> EnabledWorkerPlugins
         {
             get => _workerPlugins.Where(p => !pluginHandler.DisabledPlugins.Contains(p.plugin)).ToList();

--- a/ObservatoryCore/UI/CoreForm.Plugins.cs
+++ b/ObservatoryCore/UI/CoreForm.Plugins.cs
@@ -79,7 +79,7 @@ namespace Observatory.UI
 
         private void CreatePluginTabs()
         {
-            var uiPlugins = PluginManager.GetInstance.EnabledWorkerPlugins.Where(p => p.plugin.PluginUI.PluginUIType != Framework.PluginUI.UIType.None);
+            var uiPlugins = PluginManager.GetInstance.AllUIPlugins;
 
             PluginHelper.CreatePluginTabs(CoreTabControl, uiPlugins, pluginList);
         }


### PR DESCRIPTION
... not just *enabled* plugins. Disabled plugins need to be included because otherwise they don't re-appear when enabled until the app is restarted-- which isn't ideal.