### PR TITLE
perf(core,framework): Reduce usage of Enum.HasFlag

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -35,7 +35,7 @@ namespace Observatory.PluginManagement
             var guid = Guid.Empty;
 
 #if DEBUG // For exercising testing notifier plugins in read-all
-            if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
+            if ((notificationArgs.Rendering & NotificationRendering.PluginNotifier) != 0)
             {
                 var handler = Notification;
                 handler?.Invoke(this, notificationArgs);
@@ -44,7 +44,7 @@ namespace Observatory.PluginManagement
             if (!IsLogMonitorBatchReading)
             {
 #if !DEBUG
-                if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
+                if ((notificationArgs.Rendering & NotificationRendering.PluginNotifier) != 0)
                 {
                     var handler = Notification;
                     handler?.Invoke(this, notificationArgs);
@@ -52,14 +52,14 @@ namespace Observatory.PluginManagement
 #endif
                 if (!PluginManager.GetInstance.HasPopupOverrideNotifiers
                     && Properties.Core.Default.NativeNotify 
-                    && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVisual))
+                    && (notificationArgs.Rendering & NotificationRendering.NativeVisual) != 0)
                 {
                     guid = NativePopup.InvokeNativeNotification(notificationArgs);
                 }
 
                 if (!PluginManager.GetInstance.HasAudioOverrideNotifiers
                     && Properties.Core.Default.VoiceNotify
-                    && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
+                    && (notificationArgs.Rendering & NotificationRendering.NativeVocal) != 0)
                 {
                     NativeVoice.EnqueueAndAnnounce(notificationArgs);
                 }
@@ -77,16 +77,16 @@ namespace Observatory.PluginManagement
         {
             if (!IsLogMonitorBatchReading)
             {
-                if (notificationArgs.Rendering.HasFlag(NotificationRendering.PluginNotifier))
+                if ((notificationArgs.Rendering & NotificationRendering.PluginNotifier) != 0)
                 {
                     var handler = Notification;
                     handler?.Invoke(this, notificationArgs);
                 }
 
-                if (notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVisual))
+                if ((notificationArgs.Rendering & NotificationRendering.NativeVisual) != 0)
                     NativePopup.UpdateNotification(id, notificationArgs);
 
-                if (Properties.Core.Default.VoiceNotify && notificationArgs.Rendering.HasFlag(NotificationRendering.NativeVocal))
+                if (Properties.Core.Default.VoiceNotify && (notificationArgs.Rendering & NotificationRendering.NativeVocal) != 0)
                 {
                     NativeVoice.EnqueueAndAnnounce(notificationArgs);
                 }

--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -164,7 +164,7 @@
         /// <returns>A boolean; True iff the state provided represents a batch-mode read.</returns>
         public static bool IsBatchRead(LogMonitorState state)
         {
-            return state.HasFlag(LogMonitorState.Batch) || state.HasFlag(LogMonitorState.PreRead);
+            return (state & LogMonitorState.Batch) > 0 || (state & LogMonitorState.PreRead) > 0;
         }
     }
 }


### PR DESCRIPTION
According to the profiler, this does wasteful allocations, etc. It is recommended to use the bitwise operator. I did some profiling to figure out why a couple of my plugins were slow during read-all, and this came up.

If you like it, accept it. If not, fine too.