### PR TITLE
feat(core,framework): Add LogMonitorState.BatchCancelled

### DIFF
--- a/ObservatoryCore/UI/ReadAllProgress.cs
+++ b/ObservatoryCore/UI/ReadAllProgress.cs
@@ -30,13 +30,8 @@ namespace Observatory.UI
             HandleCreated += (_,_) =>
             Task.Run(() =>
             {
-                foreach (var journal in ReadAllJournals())
+                foreach (var journal in ReadAllJournals(ReadAllCancel))
                 {
-                    if (ReadAllCancel.IsCancellationRequested)
-                    {
-                        break;
-                    }
-
                     progressCount++;
                     Invoke(() =>
                     {

--- a/ObservatoryFramework/EventArgs.cs
+++ b/ObservatoryFramework/EventArgs.cs
@@ -139,7 +139,11 @@
         /// <summary>
         /// Batch read of recent journals is in progress to establish current player state.
         /// </summary>
-        PreRead = 4
+        PreRead = 4,
+        /// <summary>
+        /// Batch read of historical journals was stopped before completion.
+        /// </summary>
+        BatchCancelled = 8,
     }
 
     /// <summary>

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -282,6 +282,11 @@
             Batch read of recent journals is in progress to establish current player state.
             </summary>
         </member>
+        <member name="F:Observatory.Framework.LogMonitorState.BatchCancelled">
+            <summary>
+            Batch read of historical journals was stopped before completion.
+            </summary>
+        </member>
         <member name="T:Observatory.Framework.LogMonitorStateChangedEventArgs">
             <summary>
             Provides information about a LogMonitor state transition.


### PR DESCRIPTION
We now have an explicit state that is fired when you cancel a read-all. This is useful for plugins which store state that may be incomplete/unusable if read all is not complete.

State transitions will be as follows: <initial state> -> <initial state> | Batch [-> <initial state> | BatchCancelled] -> <initial state>

The BatchCancelled state is not entered if the read-all run completes normally.