### PR TITLE
chore(framework,botanist): Add a no-op column sorter to Framework

### DIFF
--- a/ObservatoryBotanist/Botanist.cs
+++ b/ObservatoryBotanist/Botanist.cs
@@ -4,6 +4,7 @@ using Observatory.Framework.Files.Journal;
 using Observatory.Framework.Interfaces;
 using Observatory.Framework.Files.ParameterTypes;
 using System.Collections.ObjectModel;
+using Observatory.Framework.Sorters;
 
 namespace Observatory.Botanist
 {
@@ -85,22 +86,7 @@ namespace Observatory.Botanist
 
         public object Settings { get => botanistSettings; set { botanistSettings = (BotanistSettings)value;  } }
 
-        #region Not Sortable
-
-        public IObservatoryComparer ColumnSorter => new Sorter();
-
-        public class Sorter : IObservatoryComparer
-        {
-            public int SortColumn { get; set; }
-            public int Order { get; set; }
-
-            public int Compare(object x, object y)
-            {
-                return 0;
-            }
-        }
-
-        #endregion
+        public IObservatoryComparer ColumnSorter => new NoOpColumnSorter();
 
         public void JournalEvent<TJournal>(TJournal journal) where TJournal : JournalBase
         {

--- a/ObservatoryFramework/Sorters/NoOpColumnSorter.cs
+++ b/ObservatoryFramework/Sorters/NoOpColumnSorter.cs
@@ -1,0 +1,21 @@
+﻿using Observatory.Framework.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.Framework.Sorters
+{
+    public class NoOpColumnSorter : IObservatoryComparer
+    {
+        public int SortColumn { get; set; }
+        public int Order { get; set; }
+
+        public int Compare(object x, object y)
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
There are likely a few other plugins (ie. any plugin which controls its own grid ordering) which likely want this too, so the idea is to make one many plugins can share to disable sorting in the new UI.

There was already such an implementation in Botanist; moved it to Framework and use it instead.