### PR TITLE
feat(core): Basic grids now support row selection, highlighting, copying

### DIFF
--- a/ObservatoryCore/UI/PluginHelper.cs
+++ b/ObservatoryCore/UI/PluginHelper.cs
@@ -6,6 +6,8 @@ using System.Text.RegularExpressions;
 using System.Reflection;
 using System.Text.Json;
 using System.Collections.Concurrent;
+using System.Text;
+using static System.Windows.Forms.ListViewItem;
 
 namespace Observatory.UI
 {
@@ -77,7 +79,6 @@ namespace Observatory.UI
 
             PluginListView listView = new()
             {
-                View = View.Details,
                 Location = new Point(0, 0),
                 Size = panel.Size,
                 Dock = DockStyle.Fill,


### PR DESCRIPTION
Selection can be multi-selections as well.

Press Ctrl+C to copy the selected rows (tab separated) to the system clipboard.

What highlighting looks like for the moment (alternating row bg coloring is maintained):

Light theme:
![Screenshot 2024-08-11 160655](https://github.com/user-attachments/assets/29934312-62ba-4595-98fd-75bd9373f4a2)

Dark theme:
![Screenshot 2024-08-11 160610](https://github.com/user-attachments/assets/51e0e3f5-ccd8-46be-a893-c75d587bb4b5)
