### PR TITLE
feat(core): New core buttons, update tab indices

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -187,8 +187,8 @@ namespace Observatory.PluginManagement
             // Return the root data directory if no plugin assembly name specified.
             if (string.IsNullOrWhiteSpace(pluginAssemblyName))
             {
-                if (!Directory.Exists(pluginDataDir))
-                    Directory.CreateDirectory(pluginDataDir);
+                if (!Directory.Exists(rootdataDir))
+                    Directory.CreateDirectory(rootdataDir);
 
                 return rootdataDir;
             }

--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -168,19 +168,36 @@ namespace Observatory.PluginManagement
             get
             {
                 var context = new System.Diagnostics.StackFrame(1).GetMethod();
+                var pluginAssemblyName = context?.DeclaringType?.Assembly.GetName().Name;
+                return GetStorageFolderForPlugin(pluginAssemblyName);
+            }
+        }
+
+        internal string GetStorageFolderForPlugin(string pluginAssemblyName = "")
+        {
 #if PORTABLE
-                string? observatoryLocation = System.Diagnostics.Process.GetCurrentProcess()?.MainModule?.FileName;
-                var obsDir = new FileInfo(observatoryLocation ?? String.Empty).DirectoryName;
-                string folderLocation = $"{obsDir}{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}{context?.DeclaringType?.Assembly.GetName().Name}-Data{Path.DirectorySeparatorChar}";
+            string? observatoryLocation = System.Diagnostics.Process.GetCurrentProcess()?.MainModule?.FileName;
+            var obsDir = new FileInfo(observatoryLocation ?? String.Empty).DirectoryName;
+            var rootdataDir = $"{obsDir}{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}";
+            string pluginDataDir = $"{rootdataDir}{pluginAssemblyName}-Data{Path.DirectorySeparatorChar}";
 #else
-                string folderLocation = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
-                    + $"{Path.DirectorySeparatorChar}ObservatoryCore{Path.DirectorySeparatorChar}{context?.DeclaringType?.Assembly.GetName().Name}{Path.DirectorySeparatorChar}";
+            var rootdataDir = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}{Path.DirectorySeparatorChar}ObservatoryCore{Path.DirectorySeparatorChar}";
+            string pluginDataDir = $"{rootdataDir}{pluginAssemblyName}{Path.DirectorySeparatorChar}";
 #endif
-                if (!Directory.Exists(folderLocation))
-                    Directory.CreateDirectory(folderLocation);
+            // Return the root data directory if no plugin assembly name specified.
+            if (string.IsNullOrWhiteSpace(pluginAssemblyName))
+            {
+                if (!Directory.Exists(pluginDataDir))
+                    Directory.CreateDirectory(pluginDataDir);
 
-                return folderLocation;
+                return rootdataDir;
+            }
+            else
+            {
+                if (!Directory.Exists(pluginDataDir))
+                    Directory.CreateDirectory(pluginDataDir);
 
+                return pluginDataDir;
             }
         }
 

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -34,6 +34,9 @@ namespace Observatory.PluginManagement
         private readonly PluginCore core;
         private readonly PluginEventHandler pluginHandler;
         
+        public PluginCore Core { get { return core; } }
+
+
         // Intended for rendering Tabs. Includes Disabled plugins.
         public List<(IObservatoryWorker plugin, PluginStatus signed)> AllUIPlugins
         {

--- a/ObservatoryCore/UI/CoreForm.Designer.cs
+++ b/ObservatoryCore/UI/CoreForm.Designer.cs
@@ -49,6 +49,7 @@
             StatusColumn = new ColumnHeader();
             PluginListButtonsLayoutPanel = new FlowLayoutPanel();
             PluginSettingsButton = new Button();
+            PluginDataDirButton = new Button();
             PluginFolderButton = new Button();
             CoreSettingsLayoutPanel = new FlowLayoutPanel();
             PopupSettingsPanel = new Panel();
@@ -83,6 +84,7 @@
             AudioDeviceLabel = new Label();
             AudioDeviceDropdown = new ComboBox();
             ExportFormatLabel = new Label();
+            CoreConfigFolder = new Button();
             AudioVolumeSlider = new TrackBar();
             ExportFormatDropdown = new ComboBox();
             CoreSettingsLabel = new Label();
@@ -122,7 +124,7 @@
             ReadAllButton.Location = new Point(770, 869);
             ReadAllButton.Name = "ReadAllButton";
             ReadAllButton.Size = new Size(75, 23);
-            ReadAllButton.TabIndex = 2;
+            ReadAllButton.TabIndex = 33;
             ReadAllButton.Text = "Read All";
             ReadAllButton.UseVisualStyleBackColor = false;
             ReadAllButton.Click += ReadAllButton_Click;
@@ -135,7 +137,7 @@
             ToggleMonitorButton.Location = new Point(667, 869);
             ToggleMonitorButton.Name = "ToggleMonitorButton";
             ToggleMonitorButton.Size = new Size(97, 23);
-            ToggleMonitorButton.TabIndex = 3;
+            ToggleMonitorButton.TabIndex = 32;
             ToggleMonitorButton.Text = "Start Monitor";
             ToggleMonitorButton.UseVisualStyleBackColor = false;
             ToggleMonitorButton.Click += ToggleMonitorButton_Click;
@@ -148,7 +150,7 @@
             ClearButton.Location = new Point(586, 869);
             ClearButton.Name = "ClearButton";
             ClearButton.Size = new Size(75, 23);
-            ClearButton.TabIndex = 4;
+            ClearButton.TabIndex = 31;
             ClearButton.Text = "Clear";
             ClearButton.UseVisualStyleBackColor = false;
             ClearButton.Click += ClearButton_Click;
@@ -161,7 +163,7 @@
             ExportButton.Location = new Point(505, 869);
             ExportButton.Name = "ExportButton";
             ExportButton.Size = new Size(75, 23);
-            ExportButton.TabIndex = 5;
+            ExportButton.TabIndex = 30;
             ExportButton.Text = "Export";
             ExportButton.UseVisualStyleBackColor = false;
             ExportButton.Click += ExportButton_Click;
@@ -173,7 +175,7 @@
             GithubLink.Location = new Point(12, 865);
             GithubLink.Name = "GithubLink";
             GithubLink.Size = new Size(42, 15);
-            GithubLink.TabIndex = 6;
+            GithubLink.TabIndex = 28;
             GithubLink.TabStop = true;
             GithubLink.Text = "github";
             GithubLink.LinkClicked += GithubLink_LinkClicked;
@@ -185,7 +187,7 @@
             DonateLink.Location = new Point(12, 880);
             DonateLink.Name = "DonateLink";
             DonateLink.Size = new Size(45, 15);
-            DonateLink.TabIndex = 7;
+            DonateLink.TabIndex = 29;
             DonateLink.TabStop = true;
             DonateLink.Text = "Donate";
             DonateLink.LinkClicked += DonateLink_LinkClicked;
@@ -203,7 +205,7 @@
             CoreTabControl.SelectedTabColor = Color.Empty;
             CoreTabControl.Size = new Size(833, 851);
             CoreTabControl.TabColor = Color.Empty;
-            CoreTabControl.TabIndex = 8;
+            CoreTabControl.TabIndex = 1;
             CoreTabControl.DrawItem += CoreTabControl_DrawItem;
             CoreTabControl.SelectedIndexChanged += CoreTabControl_SelectedIndexChanged;
             // 
@@ -240,7 +242,7 @@
             CoreSplitter.Panel2.Padding = new Padding(3);
             CoreSplitter.Size = new Size(819, 817);
             CoreSplitter.SplitterDistance = 179;
-            CoreSplitter.TabIndex = 16;
+            CoreSplitter.TabIndex = 6;
             // 
             // CoreLayoutPanel
             // 
@@ -271,7 +273,7 @@
             PluginList.Name = "PluginList";
             PluginList.OwnerDraw = true;
             PluginList.Size = new Size(813, 133);
-            PluginList.TabIndex = 8;
+            PluginList.TabIndex = 2;
             PluginList.UseCompatibleStateImageBehavior = false;
             PluginList.View = View.Details;
             PluginList.ItemChecked += PluginList_ItemChecked;
@@ -299,6 +301,7 @@
             // PluginListButtonsLayoutPanel
             // 
             PluginListButtonsLayoutPanel.Controls.Add(PluginSettingsButton);
+            PluginListButtonsLayoutPanel.Controls.Add(PluginDataDirButton);
             PluginListButtonsLayoutPanel.Controls.Add(PluginFolderButton);
             PluginListButtonsLayoutPanel.Dock = DockStyle.Fill;
             PluginListButtonsLayoutPanel.Location = new Point(3, 142);
@@ -314,20 +317,32 @@
             PluginSettingsButton.Location = new Point(3, 3);
             PluginSettingsButton.Name = "PluginSettingsButton";
             PluginSettingsButton.Size = new Size(120, 23);
-            PluginSettingsButton.TabIndex = 11;
+            PluginSettingsButton.TabIndex = 3;
             PluginSettingsButton.Text = "Plugin Settings";
             PluginSettingsButton.UseVisualStyleBackColor = false;
             PluginSettingsButton.Click += PluginSettingsButton_Click;
+            // 
+            // PluginDataDirButton
+            // 
+            PluginDataDirButton.FlatAppearance.BorderSize = 0;
+            PluginDataDirButton.FlatStyle = FlatStyle.Flat;
+            PluginDataDirButton.Location = new Point(129, 3);
+            PluginDataDirButton.Name = "PluginDataDirButton";
+            PluginDataDirButton.Size = new Size(155, 23);
+            PluginDataDirButton.TabIndex = 4;
+            PluginDataDirButton.Text = "Open Plugin Data Folder";
+            PluginDataDirButton.UseVisualStyleBackColor = true;
+            PluginDataDirButton.Click += PluginDataDirButton_Click;
             // 
             // PluginFolderButton
             // 
             PluginFolderButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             PluginFolderButton.FlatAppearance.BorderSize = 0;
             PluginFolderButton.FlatStyle = FlatStyle.Flat;
-            PluginFolderButton.Location = new Point(129, 3);
+            PluginFolderButton.Location = new Point(290, 3);
             PluginFolderButton.Name = "PluginFolderButton";
             PluginFolderButton.Size = new Size(130, 23);
-            PluginFolderButton.TabIndex = 10;
+            PluginFolderButton.TabIndex = 5;
             PluginFolderButton.Text = "Open Plugins Folder";
             PluginFolderButton.UseVisualStyleBackColor = false;
             PluginFolderButton.Click += PluginFolderButton_Click;
@@ -378,7 +393,7 @@
             DurationSpinner.Minimum = new decimal(new int[] { 100, 0, 0, 0 });
             DurationSpinner.Name = "DurationSpinner";
             DurationSpinner.Size = new Size(120, 23);
-            DurationSpinner.TabIndex = 15;
+            DurationSpinner.TabIndex = 11;
             DurationSpinner.Value = new decimal(new int[] { 8000, 0, 0, 0 });
             DurationSpinner.ValueChanged += DurationSpinner_ValueChanged;
             // 
@@ -389,7 +404,7 @@
             ScaleSpinner.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             ScaleSpinner.Name = "ScaleSpinner";
             ScaleSpinner.Size = new Size(120, 23);
-            ScaleSpinner.TabIndex = 14;
+            ScaleSpinner.TabIndex = 10;
             ScaleSpinner.Value = new decimal(new int[] { 100, 0, 0, 0 });
             ScaleSpinner.ValueChanged += ScaleSpinner_ValueChanged;
             // 
@@ -409,7 +424,7 @@
             FontDropdown.Location = new Point(117, 80);
             FontDropdown.Name = "FontDropdown";
             FontDropdown.Size = new Size(242, 23);
-            FontDropdown.TabIndex = 5;
+            FontDropdown.TabIndex = 9;
             FontDropdown.SelectedIndexChanged += FontDropdown_SelectedIndexChanged;
             // 
             // LabelColour
@@ -449,7 +464,7 @@
             TestButton.Location = new Point(187, 167);
             TestButton.Name = "TestButton";
             TestButton.Size = new Size(51, 23);
-            TestButton.TabIndex = 12;
+            TestButton.TabIndex = 13;
             TestButton.Text = "Test";
             TestButton.UseVisualStyleBackColor = false;
             TestButton.Click += TestButton_Click;
@@ -462,7 +477,7 @@
             CornerDropdown.Location = new Point(117, 51);
             CornerDropdown.Name = "CornerDropdown";
             CornerDropdown.Size = new Size(121, 23);
-            CornerDropdown.TabIndex = 3;
+            CornerDropdown.TabIndex = 8;
             CornerDropdown.SelectedIndexChanged += CornerDropdown_SelectedIndexChanged;
             // 
             // DisplayLabel
@@ -491,7 +506,7 @@
             ColourButton.Location = new Point(118, 167);
             ColourButton.Name = "ColourButton";
             ColourButton.Size = new Size(51, 23);
-            ColourButton.TabIndex = 11;
+            ColourButton.TabIndex = 12;
             ColourButton.UseVisualStyleBackColor = true;
             ColourButton.Click += ColourButton_Click;
             // 
@@ -502,7 +517,7 @@
             DisplayDropdown.Location = new Point(117, 22);
             DisplayDropdown.Name = "DisplayDropdown";
             DisplayDropdown.Size = new Size(121, 23);
-            DisplayDropdown.TabIndex = 2;
+            DisplayDropdown.TabIndex = 7;
             DisplayDropdown.SelectedIndexChanged += DisplayDropdown_SelectedIndexChanged;
             // 
             // CornerLabel
@@ -521,7 +536,7 @@
             PopupCheckbox.Location = new Point(117, 196);
             PopupCheckbox.Name = "PopupCheckbox";
             PopupCheckbox.Size = new Size(68, 19);
-            PopupCheckbox.TabIndex = 10;
+            PopupCheckbox.TabIndex = 14;
             PopupCheckbox.Text = "Enabled";
             PopupCheckbox.UseVisualStyleBackColor = true;
             PopupCheckbox.CheckedChanged += PopupCheckbox_CheckedChanged;
@@ -592,7 +607,7 @@
             VoiceTestButton.Location = new Point(178, 100);
             VoiceTestButton.Name = "VoiceTestButton";
             VoiceTestButton.Size = new Size(51, 23);
-            VoiceTestButton.TabIndex = 13;
+            VoiceTestButton.TabIndex = 18;
             VoiceTestButton.Text = "Test";
             VoiceTestButton.UseVisualStyleBackColor = false;
             VoiceTestButton.Click += VoiceTestButton_Click;
@@ -623,7 +638,7 @@
             VoiceDropdown.Location = new Point(109, 71);
             VoiceDropdown.Name = "VoiceDropdown";
             VoiceDropdown.Size = new Size(121, 23);
-            VoiceDropdown.TabIndex = 5;
+            VoiceDropdown.TabIndex = 16;
             VoiceDropdown.SelectedIndexChanged += VoiceDropdown_SelectedIndexChanged;
             // 
             // VoiceCheckbox
@@ -632,7 +647,7 @@
             VoiceCheckbox.Location = new Point(108, 103);
             VoiceCheckbox.Name = "VoiceCheckbox";
             VoiceCheckbox.Size = new Size(68, 19);
-            VoiceCheckbox.TabIndex = 11;
+            VoiceCheckbox.TabIndex = 17;
             VoiceCheckbox.Text = "Enabled";
             VoiceCheckbox.UseVisualStyleBackColor = true;
             VoiceCheckbox.CheckedChanged += VoiceCheckbox_CheckedChanged;
@@ -664,6 +679,7 @@
             CoreSettingsPanel.Controls.Add(AudioDeviceLabel);
             CoreSettingsPanel.Controls.Add(AudioDeviceDropdown);
             CoreSettingsPanel.Controls.Add(ExportFormatLabel);
+            CoreSettingsPanel.Controls.Add(CoreConfigFolder);
             CoreSettingsPanel.Controls.Add(AudioVolumeSlider);
             CoreSettingsPanel.Controls.Add(ExportFormatDropdown);
             CoreSettingsPanel.Controls.Add(CoreSettingsLabel);
@@ -697,7 +713,7 @@
             AudioDeviceDropdown.Location = new Point(121, 157);
             AudioDeviceDropdown.Name = "AudioDeviceDropdown";
             AudioDeviceDropdown.Size = new Size(214, 23);
-            AudioDeviceDropdown.TabIndex = 36;
+            AudioDeviceDropdown.TabIndex = 25;
             AudioDeviceDropdown.SelectedIndexChanged += AudioDeviceDropdown_SelectedIndexChanged;
             AudioDeviceDropdown.Click += AudioDeviceDropdown_Focused;
             // 
@@ -710,6 +726,19 @@
             ExportFormatLabel.TabIndex = 35;
             ExportFormatLabel.Text = "Export Format:";
             // 
+            // CoreConfigFolder
+            // 
+            CoreConfigFolder.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            CoreConfigFolder.FlatAppearance.BorderSize = 0;
+            CoreConfigFolder.FlatStyle = FlatStyle.Flat;
+            CoreConfigFolder.Location = new Point(455, 3);
+            CoreConfigFolder.Name = "CoreConfigFolder";
+            CoreConfigFolder.Size = new Size(90, 23);
+            CoreConfigFolder.TabIndex = 19;
+            CoreConfigFolder.Text = "Config Folder";
+            CoreConfigFolder.UseVisualStyleBackColor = true;
+            CoreConfigFolder.Click += CoreConfigFolder_Click;
+            // 
             // AudioVolumeSlider
             // 
             AudioVolumeSlider.LargeChange = 10;
@@ -717,7 +746,7 @@
             AudioVolumeSlider.Maximum = 100;
             AudioVolumeSlider.Name = "AudioVolumeSlider";
             AudioVolumeSlider.Size = new Size(214, 45);
-            AudioVolumeSlider.TabIndex = 14;
+            AudioVolumeSlider.TabIndex = 24;
             AudioVolumeSlider.TickFrequency = 10;
             AudioVolumeSlider.TickStyle = TickStyle.Both;
             AudioVolumeSlider.Value = 100;
@@ -731,7 +760,7 @@
             ExportFormatDropdown.Location = new Point(121, 54);
             ExportFormatDropdown.Name = "ExportFormatDropdown";
             ExportFormatDropdown.Size = new Size(214, 23);
-            ExportFormatDropdown.TabIndex = 34;
+            ExportFormatDropdown.TabIndex = 21;
             ExportFormatDropdown.SelectedIndexChanged += ExportFormatDropdown_SelectedIndexChanged;
             // 
             // CoreSettingsLabel
@@ -749,7 +778,7 @@
             StartReadallCheckbox.Location = new Point(117, 211);
             StartReadallCheckbox.Name = "StartReadallCheckbox";
             StartReadallCheckbox.Size = new Size(130, 19);
-            StartReadallCheckbox.TabIndex = 15;
+            StartReadallCheckbox.TabIndex = 27;
             StartReadallCheckbox.Text = "Read All On Launch";
             StartReadallCheckbox.UseVisualStyleBackColor = true;
             StartReadallCheckbox.CheckedChanged += StartReadallCheckbox_CheckedChanged;
@@ -760,7 +789,7 @@
             StartMonitorCheckbox.Location = new Point(117, 186);
             StartMonitorCheckbox.Name = "StartMonitorCheckbox";
             StartMonitorCheckbox.Size = new Size(157, 19);
-            StartMonitorCheckbox.TabIndex = 14;
+            StartMonitorCheckbox.TabIndex = 26;
             StartMonitorCheckbox.Text = "Start Monitor On Launch";
             StartMonitorCheckbox.UseVisualStyleBackColor = true;
             StartMonitorCheckbox.CheckedChanged += StartMonitorCheckbox_CheckedChanged;
@@ -800,7 +829,7 @@
             LabelJournalPath.Location = new Point(121, 32);
             LabelJournalPath.Name = "LabelJournalPath";
             LabelJournalPath.Size = new Size(424, 13);
-            LabelJournalPath.TabIndex = 13;
+            LabelJournalPath.TabIndex = 20;
             LabelJournalPath.Text = "X:\\Journal";
             LabelJournalPath.DoubleClick += LabelJournalPath_DoubleClick;
             // 
@@ -811,7 +840,7 @@
             ThemeDropdown.Location = new Point(121, 83);
             ThemeDropdown.Name = "ThemeDropdown";
             ThemeDropdown.Size = new Size(121, 23);
-            ThemeDropdown.TabIndex = 10;
+            ThemeDropdown.TabIndex = 22;
             ThemeDropdown.SelectedIndexChanged += ThemeDropdown_SelectedIndexChanged;
             // 
             // ButtonAddTheme
@@ -821,7 +850,7 @@
             ButtonAddTheme.Location = new Point(247, 83);
             ButtonAddTheme.Name = "ButtonAddTheme";
             ButtonAddTheme.Size = new Size(88, 23);
-            ButtonAddTheme.TabIndex = 11;
+            ButtonAddTheme.TabIndex = 23;
             ButtonAddTheme.Text = "Add Theme";
             ButtonAddTheme.UseVisualStyleBackColor = true;
             ButtonAddTheme.Click += ButtonAddTheme_Click;
@@ -939,5 +968,7 @@
         private ComboBox ExportFormatDropdown;
         private Label AudioDeviceLabel;
         private ComboBox AudioDeviceDropdown;
+        private Button PluginDataDirButton;
+        private Button CoreConfigFolder;
     }
 }

--- a/ObservatoryCore/UI/CoreForm.Plugins.cs
+++ b/ObservatoryCore/UI/CoreForm.Plugins.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Observatory.Framework;
 using Observatory.Utils;
 using System.Text;
+using System.Diagnostics;
 
 namespace Observatory.UI
 {
@@ -170,6 +171,27 @@ namespace Observatory.UI
                 var plugin = ListedPlugins[PluginList.SelectedItems[0]];
                 OpenSettings(plugin);
             }
+        }
+
+        private void PluginDataDirButton_Click(object sender, EventArgs e)
+        {
+            // Default to the root plugin data dir.
+            string storageDir = PluginManager.GetInstance.Core.GetStorageFolderForPlugin();
+
+            if (ListedPlugins != null && PluginList.SelectedItems.Count != 0)
+            {
+                var plugin = ListedPlugins[PluginList.SelectedItems[0]];
+                storageDir = PluginManager.GetInstance.Core.GetStorageFolderForPlugin(plugin.GetType().Assembly.GetName().Name ?? "");
+
+            }
+
+            if (string.IsNullOrWhiteSpace(storageDir) || !Directory.Exists(storageDir))
+            {
+                return; // Unexpected; but do nothing.
+            }
+
+            var fileExplorerInfo = new ProcessStartInfo() { FileName = storageDir, UseShellExecute = true };
+            Process.Start(fileExplorerInfo);
         }
 
         private void PluginsEnabledStateFromSettings()

--- a/ObservatoryCore/UI/CoreForm.Settings.cs
+++ b/ObservatoryCore/UI/CoreForm.Settings.cs
@@ -1,6 +1,8 @@
 using NAudio.Wave;
 using Observatory.Framework;
 using Observatory.Utils;
+using System.Configuration;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace Observatory.UI
@@ -129,6 +131,9 @@ namespace Observatory.UI
             VoiceDisabledLabel.Text = "Native voice notifications not available in this build.";
             VoiceDisabledPanel.BringToFront();
 #endif
+#if !DEBUG
+            CoreConfigFolder.Visible = false;
+#endif
         }
 
         static private void TryLoadSetting(Control control, string property, object newValue)
@@ -236,6 +241,25 @@ namespace Observatory.UI
         {
             Properties.Core.Default.ExportFormat = ExportFormatDropdown.SelectedIndex;
             SettingsManager.Save();
+        }
+        private void CoreConfigFolder_Click(object sender, EventArgs e)
+        {
+#if PORTABLE
+            string? observatoryLocation = System.Diagnostics.Process.GetCurrentProcess()?.MainModule?.FileName;
+            var configDir = new FileInfo(observatoryLocation ?? String.Empty).DirectoryName;
+#else
+            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
+            var fileInfo = new FileInfo(config.FilePath);
+            var configDir = fileInfo.DirectoryName;
+#endif
+
+            if (string.IsNullOrWhiteSpace(configDir) || !Directory.Exists(configDir))
+            {
+                return;
+            }
+
+            var fileExplorerInfo = new ProcessStartInfo() { FileName = configDir, UseShellExecute = true };
+            Process.Start(fileExplorerInfo);
         }
     }
 }


### PR DESCRIPTION
New buttons:
* Plugin Data Folder: Opens the selected plugin's data folder. If no plugin selected, the root plugin data folder. Located below the plugin list.
* Core Config Folder: Opens the location of the ObsCore config. This button is only visible in DEBUG builds (by way of compiler conditions). Located in the top-right corner of the Core Settings box.

To expose the plugin data folders and share logic, I did a bit of refactoring in PluginCore. And it seems CoreForm had no reference to PluginCore -- so made that accessible via PluginManager.

Did a bonus pass over tab indices to make controls sensibly ordered.

![Screenshot 2024-08-11 175221](https://github.com/user-attachments/assets/770c2506-324c-48d3-be92-374eae6cbbb8)
