### PR TITLE
fix(core): Targeted notifications now received by overriding notifiers

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -63,7 +63,7 @@ namespace Observatory.PluginManagement
                     {
                         guid = NativePopup.InvokeNativeNotification(notificationArgs);
                     }
-                    else if (PluginManager.GetInstance.HasPopupOverrideNotifiers)
+                    else if (PluginManager.GetInstance.HasPopupOverrideNotifiers && (notificationArgs.Rendering & NotificationRendering.PluginNotifier) == 0)
                     {
                         // We have an overriding plugin for a native handler. Route it there.
                         handler?.Invoke(this, notificationArgs);
@@ -76,7 +76,7 @@ namespace Observatory.PluginManagement
                     {
                         NativeVoice.AudioHandlerEnqueue(notificationArgs);
                     }
-                    else if (PluginManager.GetInstance.HasAudioOverrideNotifiers)
+                    else if (PluginManager.GetInstance.HasAudioOverrideNotifiers && (notificationArgs.Rendering & NotificationRendering.PluginNotifier) == 0)
                     {
                         // We have an overriding plugin for a native handler.
                         handler?.Invoke(this, notificationArgs);

--- a/ObservatoryCore/PluginManagement/PluginEventHandler.cs
+++ b/ObservatoryCore/PluginManagement/PluginEventHandler.cs
@@ -101,7 +101,17 @@ namespace Observatory.PluginManagement
                 if (disabledPlugins.Contains(notifier)) continue;
                 try
                 {
-                    notifier.OnNotificationEvent(notificationArgs);
+                    // We may get notifications that are not PluginNotifier destined if we have
+                    // a plugin which overrides a native handler. Only deliver native notifications if
+                    // the plugin declares it's overriding.
+                    if ((notifier.OverrideAudioNotifications 
+                            && (notificationArgs.Rendering & NotificationRendering.NativeVocal) != 0)
+                        || (notifier.OverridePopupNotifications
+                            && (notificationArgs.Rendering & NotificationRendering.NativeVisual) != 0)
+                        || (notificationArgs.Rendering & NotificationRendering.PluginNotifier) != 0)
+                    {
+                        notifier.OnNotificationEvent(notificationArgs);
+                    }
                 }
                 catch (PluginException ex)
                 {


### PR DESCRIPTION
MattG reported that targeting ONLY a native notifier (ie. voice or visual) when there was an override in place was not received. We've never noticed that because apparently nobody's targeted *only* NativeVocal and there's no NativeVisual notifiers (yet). (It worked it PluginNotifier was also targeted.)

So yeah, turns out that was not handled correctly; and it's now fixed.

Tested with hacking up my Helm (targeted notification sender) and Aggregator (overriding notification receiver) plugins and Herald.