### PR TITLE
feat(core,framework): Allow plugins to opt in to batch-mode notifications

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -43,20 +43,15 @@ namespace Observatory.PluginManagement
             var guid = Guid.Empty;
             var handler = Notification;
 
-#if DEBUG // For exercising testing notifier plugins in read-all
+            // Always send notifications to plugins. PluginEventHandler filters out plugins
+            // which have not explicitly allowed batch-mode notifications.
             if ((notificationArgs.Rendering & NotificationRendering.PluginNotifier) != 0)
             {
                 handler?.Invoke(this, notificationArgs);
             }
-#endif
+
             if (!IsLogMonitorBatchReading)
             {
-#if !DEBUG
-                if ((notificationArgs.Rendering & NotificationRendering.PluginNotifier) != 0)
-                {
-                    handler?.Invoke(this, notificationArgs);
-                }
-#endif
                 if ((notificationArgs.Rendering & NotificationRendering.NativeVisual) != 0)
                 {
                     if (Properties.Core.Default.NativeNotify && !PluginManager.GetInstance.HasPopupOverrideNotifiers)

--- a/ObservatoryCore/PluginManagement/PluginEventHandler.cs
+++ b/ObservatoryCore/PluginManagement/PluginEventHandler.cs
@@ -99,6 +99,9 @@ namespace Observatory.PluginManagement
             foreach (var notifier in observatoryNotifiers)
             {
                 if (disabledPlugins.Contains(notifier)) continue;
+                if (LogMonitorStateChangedEventArgs.IsBatchRead(LogMonitor.GetInstance.CurrentState)
+                    && !notifier.OverrideAcceptNotificationsDuringBatch) continue;
+
                 try
                 {
                     // We may get notifications that are not PluginNotifier destined if we have

--- a/ObservatoryFramework/Interfaces.cs
+++ b/ObservatoryFramework/Interfaces.cs
@@ -177,6 +177,14 @@ namespace Observatory.Framework.Interfaces
         /// </summary>
         public bool OverridePopupNotifications
         { get => false; }
+
+        /// <summary>
+        /// A property set by notification plugins to indicate to Core
+        /// that it would like to receive notifications during batch read
+        /// operations (eg. pre-read and read-all).
+        /// </summary>
+        public bool OverrideAcceptNotificationsDuringBatch
+        { get => false; }
     }
 
     /// <summary>

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -1641,6 +1641,13 @@
             that native popup notifications should be disabled/suppressed.
             </summary>
         </member>
+        <member name="P:Observatory.Framework.Interfaces.IObservatoryNotifier.OverrideAcceptNotificationsDuringBatch">
+            <summary>
+            A property set by notification plugins to indicate to Core
+            that it would like to receive notifications during batch read
+            operations (eg. pre-read and read-all).
+            </summary>
+        </member>
         <member name="T:Observatory.Framework.Interfaces.IObservatoryCore">
             <summary>
             Interface passed by Observatory Core to plugins. Primarily used for sending notifications and UI updates back to Core.


### PR DESCRIPTION
Add a boolean property to the IObservatoryNotifier interface that allows a plugin to override the default suppression of sending notifications to plugins notifiers. This must be explicitly set by interested plugins so existing notifiers will not suddenly receive all the batch-read notifications.

This has the side benefit of cleaning up a couple bits of duplicate code wrapped in mutually exclusive `#ifdef` blocks.

This will enable some desireable functionality in Aggregator (showing notifications generated via pre-read and some testing via read-all) without negative impact to existing plugins (like telegram and StellarOverlay -- which presently spams me with notifications if I forget to disable it).