### PR TITLE
fix(core): Numerous theme-related fixes and refactoring

### DIFF
--- a/ObservatoryCore/UI/ColourableTabControl.cs
+++ b/ObservatoryCore/UI/ColourableTabControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -8,7 +9,63 @@ namespace Observatory.UI
 {
     public class ColourableTabControl : TabControl
     {
+        public ColourableTabControl() : base()
+        {
+            DrawMode = TabDrawMode.OwnerDrawFixed;
+        }
+
+        override protected void OnDrawItem(DrawItemEventArgs e)
+        {
+            base.OnDrawItem(e);
+            e.Graphics.FillRectangle(new SolidBrush(BackColor), ClientRectangle);
+
+            for (int i = 0; i < TabPages.Count; i++)
+            {
+                var tab = TabPages[i];
+                var selected = SelectedIndex == i;
+                var tabArea = GetTabRect(i);
+                var stringFormat = new StringFormat()
+                {
+                    LineAlignment = StringAlignment.Center,
+                    Alignment = StringAlignment.Center
+                };
+                if (selected)
+                {
+                    try
+                    {
+                        e.Graphics.FillRectangle(new SolidBrush(SelectedTabColor), tabArea);
+                    }
+                    catch (ExternalException ex) // A generic error occurred in GDI+.
+                    {
+                        // This happens sometimes randomly when resizing things a bunch, but doesn't seem to break anything.
+                    }
+                    tabArea.Offset(-1, -1);
+                }
+                else
+                {
+                    try
+                    {
+                        e.Graphics.FillRectangle(new SolidBrush(TabColor), tabArea);
+                    }
+                    catch (ExternalException ex) // A generic error occurred in GDI+.
+                    {
+                        // This happens sometimes randomly when resizing things a bunch, but doesn't seem to break anything.
+                    }
+                    tabArea.Offset(1, 1);
+                }
+
+                if (Alignment == TabAlignment.Left)
+                {
+                    stringFormat.FormatFlags = StringFormatFlags.DirectionVertical;
+                }
+
+                e.Graphics.DrawString(tab.Text, Font ?? new Font("Segoe UI", 9), new SolidBrush(ForeColor), tabArea, stringFormat);
+            }
+        }
+
         public Color TabColor { get; set; }
         public Color SelectedTabColor { get; set; }
+
+        public override Color BackColor { get; set; }
     }
 }

--- a/ObservatoryCore/UI/CoreForm.Designer.cs
+++ b/ObservatoryCore/UI/CoreForm.Designer.cs
@@ -203,7 +203,6 @@
             CoreTabControl.Size = new Size(833, 851);
             CoreTabControl.TabColor = Color.Empty;
             CoreTabControl.TabIndex = 1;
-            CoreTabControl.DrawItem += CoreTabControl_DrawItem;
             CoreTabControl.SelectedIndexChanged += CoreTabControl_SelectedIndexChanged;
             // 
             // CoreTabPage
@@ -890,7 +889,7 @@
             ThemeDropdown.FormattingEnabled = true;
             ThemeDropdown.Location = new Point(117, 83);
             ThemeDropdown.Name = "ThemeDropdown";
-            ThemeDropdown.Size = new Size(121, 23);
+            ThemeDropdown.Size = new Size(214, 23);
             ThemeDropdown.TabIndex = 22;
             ThemeDropdown.SelectedIndexChanged += ThemeDropdown_SelectedIndexChanged;
             // 
@@ -898,7 +897,7 @@
             // 
             ButtonAddTheme.FlatAppearance.BorderSize = 0;
             ButtonAddTheme.FlatStyle = FlatStyle.Flat;
-            ButtonAddTheme.Location = new Point(271, 82);
+            ButtonAddTheme.Location = new Point(344, 81);
             ButtonAddTheme.Name = "ButtonAddTheme";
             ButtonAddTheme.Size = new Size(88, 23);
             ButtonAddTheme.TabIndex = 23;

--- a/ObservatoryCore/UI/CoreForm.Settings.cs
+++ b/ObservatoryCore/UI/CoreForm.Settings.cs
@@ -185,6 +185,28 @@ namespace Observatory.UI
             }
         }
 
+        private void ApplySelectedTheme()
+        {
+            try
+            {
+                themeManager.CurrentTheme = ThemeDropdown.SelectedItem?.ToString() ?? themeManager.CurrentTheme;
+                Properties.Core.Default.Theme = themeManager.CurrentTheme;
+                foreach (var (plugin, _) in PluginManager.GetInstance.AllUIPlugins)
+                {
+                    plugin.ThemeChanged(themeManager.CurrentTheme, themeManager.CurrentThemeDetails);
+                }
+                SettingsManager.Save();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    ex.Message,
+                    "Error applying theme",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+        }
+
         private void TestButton_Click(object sender, EventArgs e)
         {
             NotificationArgs args = new()
@@ -214,13 +236,7 @@ namespace Observatory.UI
 
         private void ThemeDropdown_SelectedIndexChanged(object sender, EventArgs e)
         {
-            themeManager.CurrentTheme = ThemeDropdown.SelectedItem?.ToString() ?? themeManager.CurrentTheme;
-            Properties.Core.Default.Theme = themeManager.CurrentTheme;
-            foreach(var (plugin, _) in PluginManager.GetInstance.AllUIPlugins)
-            {
-                plugin.ThemeChanged(themeManager.CurrentTheme, themeManager.CurrentThemeDetails);
-            }
-            SettingsManager.Save();
+            ApplySelectedTheme();
         }
 
         private void ButtonAddTheme_Click(object sender, EventArgs e)
@@ -236,7 +252,10 @@ namespace Observatory.UI
                 {
                     var fileContent = File.ReadAllText(fileBrowse.FileName);
                     var themeName = themeManager.AddTheme(fileContent);
-                    ThemeDropdown.Items.Add(themeName);
+                    if (!ThemeDropdown.Items.Contains(themeName))
+                        ThemeDropdown.Items.Add(themeName);
+                    if (themeName.Equals(ThemeDropdown.SelectedItem?.ToString()))
+                        ApplySelectedTheme();
                 }
                 catch (Exception ex)
                 {

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -384,54 +384,6 @@ namespace Observatory.UI
             }
         }
 
-        private void CoreTabControl_DrawItem(object sender, DrawItemEventArgs e)
-        {
-            e.Graphics.FillRectangle(new SolidBrush(BackColor), CoreTabControl.ClientRectangle);
-
-            for (int i = 0; i < CoreTabControl.TabPages.Count; i++)
-            {
-                var tab = CoreTabControl.TabPages[i];
-                var selected = CoreTabControl.SelectedIndex == i;
-                var tabArea = CoreTabControl.GetTabRect(i);
-                var stringFormat = new StringFormat()
-                {
-                    LineAlignment = StringAlignment.Center,
-                    Alignment = StringAlignment.Center
-                };
-                if (selected)
-                {
-                    try
-                    {
-                        e.Graphics.FillRectangle(new SolidBrush(CoreTabControl.SelectedTabColor), tabArea);
-                    }
-                    catch (ExternalException ex) // A generic error occurred in GDI+.
-                    {
-                        // This happens sometimes randomly when resizing things a bunch, but doesn't seem to break anything.
-                    }
-                    tabArea.Offset(-1, -1);
-                }
-                else
-                {
-                    try
-                    {
-                        e.Graphics.FillRectangle(new SolidBrush(CoreTabControl.TabColor), tabArea);
-                    }
-                    catch (ExternalException ex) // A generic error occurred in GDI+.
-                    {
-                        // This happens sometimes randomly when resizing things a bunch, but doesn't seem to break anything.
-                    }
-                    tabArea.Offset(1, 1);
-                }
-
-                if (CoreTabControl.Alignment == TabAlignment.Left)
-                {
-                    stringFormat.FormatFlags = StringFormatFlags.DirectionVertical;
-                }
-
-                e.Graphics.DrawString(tab.Text, e.Font ?? new Font("Segoe UI", 9), new SolidBrush(tab.ForeColor), tabArea, stringFormat);
-            }
-        }
-
         private void RestoreSavedTab()
         {
             CoreTabControl.SelectedIndex = Properties.Core.Default.LastTabIndex < CoreTabControl.TabPages.Count

--- a/ObservatoryCore/UI/CoreForm.resx
+++ b/ObservatoryCore/UI/CoreForm.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter


### PR DESCRIPTION
* Moved the ColourableTabControl.DrawItem event into the ColourableTabControl class itself, out of CoreForm, as discussed.
* Widened the Theme picker drop-down to be the same size as the font drop-down.
* Add some error handling around applying a theme to prevent application crashes if something like an invalid color is applied to certain properties (notably DataGridView's GridColor).
* When adding a theme which already exists, don't duplicate it in the drop-list (it's already de-duped in the manager).
* When adding a theme which is currently selected, reapply it.
* Apply JSON serialization options to make writing a theme file a little more forgiving and less error prone. It also makes the version stored in the settings more compact by omitting null values.
* In Debug mode, spit out a list of keys discovered by the themer to debug output. I suspect we should publish these because I don't know how anyone would ever discover them. (Locally, I got almost 100 keys.)

![image](https://github.com/user-attachments/assets/2a00bb9e-b530-4028-8fa7-fa0ae9f22952)
