### PR TITLE
fix(core): FocusPlugin activates popout, prevent duplicate windows

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -272,7 +272,7 @@ namespace Observatory.PluginManagement
         {
             ExecuteOnUIThread(() =>
             {
-                FormsManager.OpenPluginAboutForm(plugin);
+                FormsManager.OpenAboutForm(plugin.AboutInfo);
             });
         }
 

--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -166,7 +166,7 @@ namespace Observatory.PluginManagement
 
         public void ExecuteOnUIThread(Action action)
         {
-            FindCoreForm()?.Invoke(action);
+            FormsManager.FindCoreForm()?.Invoke(action);
         }
 
         public System.Net.Http.HttpClient HttpClient
@@ -264,7 +264,7 @@ namespace Observatory.PluginManagement
         {
             ExecuteOnUIThread(() =>
             {
-                FindCoreForm()?.OpenSettings(plugin);
+                FormsManager.OpenPluginSettingsForm(plugin);
             });
         }
 
@@ -272,7 +272,7 @@ namespace Observatory.PluginManagement
         {
             ExecuteOnUIThread(() =>
             {
-                FindCoreForm()?.OpenAbout(plugin.AboutInfo);
+                FormsManager.OpenPluginAboutForm(plugin);
             });
         }
 
@@ -286,7 +286,7 @@ namespace Observatory.PluginManagement
         {
             ExecuteOnUIThread(() =>
             {
-                FindCoreForm()?.FocusPlugin(pluginName);
+                FormsManager.FocusPluginTabOrWindow(pluginName);
             });
         }
 
@@ -327,18 +327,6 @@ namespace Observatory.PluginManagement
                         return listView;
                     }
                 }
-            return null;
-        }
-
-        private static CoreForm? FindCoreForm()
-        {
-            foreach (var f in Application.OpenForms)
-            {
-                if (f is CoreForm form)
-                {
-                    return form;
-                }
-            }
             return null;
         }
     }

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -242,20 +242,7 @@ namespace Observatory.UI
 
         private void AboutCore_Click(object sender, EventArgs e)
         {
-            string coreSettingsTitle = "Core Settings";
-            Form? coreAbout = FormsManager.GetFormByTitle(coreSettingsTitle);
-            
-            if (coreAbout == null)
-            {
-                coreAbout = new AboutForm(_aboutCore);
-                coreAbout.Text = coreSettingsTitle;
-                ThemeManager.GetInstance.RegisterControl(coreAbout);
-                coreAbout.Show();
-            }
-            else
-            {
-                coreAbout.Activate();
-            }
+            FormsManager.OpenAboutForm(_aboutCore);
         }
 
         private static void OpenURL(string url)

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -242,17 +242,19 @@ namespace Observatory.UI
 
         private void AboutCore_Click(object sender, EventArgs e)
         {
-            OpenAbout(_aboutCore);
-        }
-
-        // Also used for plugins.
-        internal void OpenAbout(AboutInfo aboutInfo)
-        {
-            if (aboutInfo != null)
+            string coreSettingsTitle = "Core Settings";
+            Form? coreAbout = FormsManager.GetFormByTitle(coreSettingsTitle);
+            
+            if (coreAbout == null)
             {
-                var aboutForm = new AboutForm(aboutInfo);
-                ThemeManager.GetInstance.RegisterControl(aboutForm);
-                aboutForm.Show();
+                coreAbout = new AboutForm(_aboutCore);
+                coreAbout.Text = coreSettingsTitle;
+                ThemeManager.GetInstance.RegisterControl(coreAbout);
+                coreAbout.Show();
+            }
+            else
+            {
+                coreAbout.Activate();
             }
         }
 
@@ -402,23 +404,6 @@ namespace Observatory.UI
 
             PluginHelper.CreatePluginTabs(CoreTabControl, uiPlugins, pluginList, columnSizing ?? []);
         }
-
-        internal void OpenSettings(IObservatoryPlugin plugin)
-        {
-            if (SettingsForms.ContainsKey(plugin))
-            {
-                SettingsForms[plugin].Activate();
-            }
-            else
-            {
-                SettingsForm settingsForm = new(plugin);
-                SettingsForms.Add(plugin, settingsForm);
-                settingsForm.FormClosed += (_, _) => SettingsForms.Remove(plugin);
-                settingsForm.Show();
-            }
-        }
-
-        private Dictionary<IObservatoryPlugin, SettingsForm> SettingsForms = [];
 
         private static void PluginExport(IObservatoryPlugin plugin)
         {

--- a/ObservatoryCore/UI/FormsManager.cs
+++ b/ObservatoryCore/UI/FormsManager.cs
@@ -1,0 +1,98 @@
+﻿using Observatory.Framework.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.UI
+{
+    internal class FormsManager
+    {
+        public static CoreForm? FindCoreForm()
+        {
+            foreach (var f in Application.OpenForms)
+            {
+                if (f is CoreForm form)
+                {
+                    return form;
+                }
+            }
+            return null;
+        }
+
+        public static Form? GetFormByTitle(string title)
+        {
+            foreach (Form form in Application.OpenForms)
+            {
+                if (form.Text == title)
+                    return form;
+            }
+            return null;
+        }
+
+        public static void OpenPluginAboutForm(IObservatoryPlugin plugin)
+        {
+            if (plugin.AboutInfo != null)
+            {
+                var form = GetFormByTitle($"About {plugin.AboutInfo.FullName}");
+                if (form != null)
+                {
+                    form.Activate();
+                }
+                else
+                {
+                    var aboutForm = new AboutForm(plugin.AboutInfo);
+                    ThemeManager.GetInstance.RegisterControl(aboutForm);
+                    aboutForm.FormClosing += (_, _) => ThemeManager.GetInstance.UnregisterControl(aboutForm);
+                    aboutForm.Show();
+                }
+            }
+        }
+
+        public static void OpenPluginSettingsForm(IObservatoryPlugin plugin)
+        {
+            var settingsTitle = $"{plugin.Name} Settings";
+            var form = GetFormByTitle(settingsTitle);
+            if (form != null)
+            {
+                form.Activate();
+            }
+            else
+            {
+                var settingsForm = new SettingsForm(plugin);
+                settingsForm.Show();
+            }
+        }
+
+        public static void OpenPluginPopoutForm(IObservatoryPlugin plugin, TabPage? pluginTab = null)
+        {
+            var form = GetFormByTitle(plugin.Name);
+            if (form != null)
+            {
+                form.Activate();
+            }
+            else
+            {
+                var popoutForm = new PopoutForm(pluginTab, plugin);
+                ThemeManager.GetInstance.RegisterControl(popoutForm);
+                popoutForm.Show();
+            }
+        }
+
+        public static void FocusPluginTabOrWindow(string pluginName)
+        {
+            // Check first if the plugin is popped out and activate/raise that window.
+            Form? pluginPopout = FormsManager.GetFormByTitle(pluginName);
+            if (pluginPopout != null)
+            {
+                pluginPopout.Activate();
+            }
+            else
+            {
+                // Otherwise, switch the main window to that tab.
+                FindCoreForm()?.FocusPlugin(pluginName);
+            }
+        }
+    }
+}

--- a/ObservatoryCore/UI/FormsManager.cs
+++ b/ObservatoryCore/UI/FormsManager.cs
@@ -1,4 +1,5 @@
-﻿using Observatory.Framework.Interfaces;
+﻿using Observatory.Framework;
+using Observatory.Framework.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,18 +32,18 @@ namespace Observatory.UI
             return null;
         }
 
-        public static void OpenPluginAboutForm(IObservatoryPlugin plugin)
+        public static void OpenAboutForm(AboutInfo? aboutInfo)
         {
-            if (plugin.AboutInfo != null)
+            if (aboutInfo != null)
             {
-                var form = GetFormByTitle($"About {plugin.AboutInfo.FullName}");
+                var form = GetFormByTitle($"About {aboutInfo.FullName}");
                 if (form != null)
                 {
                     form.Activate();
                 }
                 else
                 {
-                    var aboutForm = new AboutForm(plugin.AboutInfo);
+                    var aboutForm = new AboutForm(aboutInfo);
                     ThemeManager.GetInstance.RegisterControl(aboutForm);
                     aboutForm.FormClosing += (_, _) => ThemeManager.GetInstance.UnregisterControl(aboutForm);
                     aboutForm.Show();

--- a/ObservatoryCore/UI/PluginContextMenu.cs
+++ b/ObservatoryCore/UI/PluginContextMenu.cs
@@ -37,49 +37,15 @@ namespace Observatory.UI
             {
                 if (e.ClickedItem == popout)
                 {
-                    var form = GetFormByTitle(plugin.Name);
-                    if (form != null)
-                    {
-                        form.Activate();
-                    }
-                    else
-                    {
-                        var popoutForm = new PopoutForm(pluginTab, plugin);
-                        ThemeManager.GetInstance.RegisterControl(popoutForm);
-                        popoutForm.Show();
-                    }
+                    FormsManager.OpenPluginPopoutForm(plugin, pluginTab);
                 }
                 if (e.ClickedItem == settings)
                 {
-                    var settingsTitle = $"{plugin.Name} Settings";
-                    var form = GetFormByTitle(settingsTitle);
-                    if (form != null)
-                    {
-                        form.Activate();
-                    }
-                    else
-                    {
-                        var settingsForm = new SettingsForm(plugin);
-                        settingsForm.Show();
-                    }
+                    FormsManager.OpenPluginSettingsForm(plugin);
                 }
                 if (e.ClickedItem == about)
                 {
-                    if (plugin.AboutInfo != null)
-                    {
-                        var form = GetFormByTitle($"About {plugin.AboutInfo.FullName}");
-                        if (form != null)
-                        {
-                            form.Activate();
-                        }
-                        else
-                        {
-                            var aboutForm = new AboutForm(plugin.AboutInfo);
-                            ThemeManager.GetInstance.RegisterControl(aboutForm);
-                            aboutForm.FormClosing += (_, _) => ThemeManager.GetInstance.UnregisterControl(aboutForm);
-                            aboutForm.Show();
-                        }
-                    }
+                    FormsManager.OpenPluginAboutForm(plugin);
                 }
                 if (e.ClickedItem == folder)
                 {
@@ -92,16 +58,6 @@ namespace Observatory.UI
                     }
                 }
             };
-        }
-
-        private Form? GetFormByTitle(string title)
-        {
-            foreach (Form form in Application.OpenForms)
-            {
-                if (form.Text == title)
-                    return form;
-            }
-            return null;
         }
     }
 }

--- a/ObservatoryCore/UI/PluginContextMenu.cs
+++ b/ObservatoryCore/UI/PluginContextMenu.cs
@@ -1,4 +1,5 @@
-﻿using Observatory.Framework.Interfaces;
+﻿using Observatory.Framework;
+using Observatory.Framework.Interfaces;
 using Observatory.PluginManagement;
 using System.Diagnostics;
 
@@ -45,7 +46,7 @@ namespace Observatory.UI
                 }
                 if (e.ClickedItem == about)
                 {
-                    FormsManager.OpenPluginAboutForm(plugin);
+                    FormsManager.OpenAboutForm(plugin.AboutInfo);
                 }
                 if (e.ClickedItem == folder)
                 {

--- a/ObservatoryCore/UI/PopoutForm.cs
+++ b/ObservatoryCore/UI/PopoutForm.cs
@@ -169,27 +169,7 @@ namespace Observatory.UI
 
         private void SettingsButton_Click(object sender, EventArgs e)
         {
-            var settingsTitle = $"{_plugin.Name} Settings";
-            var form = GetFormByTitle(settingsTitle);
-            if (form != null)
-            {
-                form.Activate();
-            }
-            else
-            {
-                var settingsForm = new SettingsForm(_plugin);
-                settingsForm.Show();
-            }
-        }
-
-        private static Form? GetFormByTitle(string title)
-        {
-            foreach (Form form in Application.OpenForms)
-            {
-                if (form.Text == title)
-                    return form;
-            }
-            return null;
+            FormsManager.OpenPluginSettingsForm(_plugin);
         }
 
         private class PopoutPosition


### PR DESCRIPTION
After adding popout windows, FocusPlugin would unhelpfully focus an empty tab. Now it activates the existing popout window or switches the main window tab.

Furthermore, when activating plugin settings or about via PluginCore, you could open many many duplicates in some cases. Now, all this goes through a manager (scraped out of the plugin tab context menu handler) which first searches for the window being opened and activates it instead of opening a duplicate, otherwise opens a new. Add similar protection around the Core About button.

All these form handling methods have been refactored into a "FormsManager" class for uniform handling.

Cleaned up a bit of unused stuff as a result of some of this refactoring.
