### PR TITLE
fix(core): Clamp numeric settings before assigning to Value

### DIFF
--- a/ObservatoryCore/UI/SettingsForm.cs
+++ b/ObservatoryCore/UI/SettingsForm.cs
@@ -295,7 +295,7 @@ namespace Observatory.UI
                 Maximum = maxBound,
             };
 
-            trackBar.Value = (int?)setting.GetValue(_plugin.Settings) ?? 0;
+            trackBar.Value = Math.Clamp((int?)setting.GetValue(_plugin.Settings) ?? 0, minBound, maxBound);
 
             trackBar.ValueChanged += (sender, e) =>
             {
@@ -317,7 +317,7 @@ namespace Observatory.UI
                 Increment = Convert.ToInt32(bounds?.Increment ?? 1)
             };
 
-            numericUpDown.Value = (int?)setting.GetValue(_plugin.Settings) ?? 0;
+            numericUpDown.Value = Math.Clamp((int?)setting.GetValue(_plugin.Settings) ?? 0, numericUpDown.Minimum, numericUpDown.Maximum);
             numericUpDown.ValueChanged += (sender, e) =>
             {
                 setting.SetValue(_plugin.Settings, Convert.ToInt32(numericUpDown.Value));
@@ -339,7 +339,7 @@ namespace Observatory.UI
                 DecimalPlaces = bounds?.Precision ?? 1,
             };
 
-            numericUpDown.Value = Convert.ToDecimal(setting.GetValue(_plugin.Settings) ?? 0);
+            numericUpDown.Value = Math.Clamp(Convert.ToDecimal(setting.GetValue(_plugin.Settings) ?? 0), numericUpDown.Minimum, numericUpDown.Maximum);
             numericUpDown.ValueChanged += (sender, e) =>
             {
                 setting.SetValue(_plugin.Settings, Convert.ToDouble(numericUpDown.Value));


### PR DESCRIPTION
The NumericUpDown control Value property will throw if the value is out of bounds.

This can happen if a plugin sets bounds on a setting that does not include zero but does not initialize the value (typically when adding a new numeric value to a settings config that already exists).