### PR TITLE
fix(core): Minor FocusPlugin fix

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -284,10 +284,24 @@ namespace Observatory.PluginManagement
 
         public void FocusPlugin(string pluginName)
         {
-            ExecuteOnUIThread(() =>
+            // pluginName here is based on "short name" whereas windows are named using full name.
+            // Find the plugin by short name and proceed with the full name.
+            IObservatoryPlugin? plugin = null;
+            foreach (var p in PluginManager.GetInstance.AllUIPlugins)
             {
-                FormsManager.FocusPluginTabOrWindow(pluginName);
-            });
+                if (p.ShortName == pluginName)
+                {
+                    plugin = p;
+                    break;
+                }
+            }
+            if (plugin != null)
+            {
+                ExecuteOnUIThread(() =>
+                {
+                    FormsManager.FocusPluginTabOrWindow(plugin);
+                });
+            }
         }
 
         internal void Shutdown()

--- a/ObservatoryCore/UI/FormsManager.cs
+++ b/ObservatoryCore/UI/FormsManager.cs
@@ -81,10 +81,10 @@ namespace Observatory.UI
             }
         }
 
-        public static void FocusPluginTabOrWindow(string pluginName)
+        public static void FocusPluginTabOrWindow(IObservatoryPlugin plugin)
         {
             // Check first if the plugin is popped out and activate/raise that window.
-            Form? pluginPopout = FormsManager.GetFormByTitle(pluginName);
+            Form? pluginPopout = FormsManager.GetFormByTitle(plugin.Name);
             if (pluginPopout != null)
             {
                 pluginPopout.Activate();
@@ -92,7 +92,7 @@ namespace Observatory.UI
             else
             {
                 // Otherwise, switch the main window to that tab.
-                FindCoreForm()?.FocusPlugin(pluginName);
+                FindCoreForm()?.FocusPlugin(plugin.ShortName);
             }
         }
     }


### PR DESCRIPTION
Tabs use short name but windows use the full name. The original FocusPlugin implementation used the short name passed in from the calling plugin forwarded to it (likely) from a notification sender. This would only succeed in focusing a popped-out window if the Short name and Full name matched. There are plugins for which this is not true (ie. Commander vs. Fleet Commander).

Update PluginCore to find the plugin instance with the corresponding short name and use pass the plugin instance to the method which can then use either the full name to find the window or the short name to find the tab.