### PR TITLE
Update Plugin Messaging

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -237,7 +237,11 @@ namespace Observatory.PluginManagement
 
         public void SendPluginMessage(IObservatoryPlugin plugin, object message)
         {
-            PluginMessage?.Invoke(this, new PluginMessageArgs(plugin.Name, plugin.Version, message));
+            PluginMessage?.Invoke(this, new PluginMessageArgs(plugin.Name, plugin.Version, String.Empty, message));
+        }
+        public void SendPluginMessage(IObservatoryPlugin plugin, string targetShortName, object message)
+        {
+            PluginMessage?.Invoke(this, new PluginMessageArgs(plugin.Name, plugin.Version, targetShortName, message));
         }
 
         public void RegisterControl(object control, Func<object, bool> applyTheme)

--- a/ObservatoryCore/PluginManagement/PluginEventHandler.cs
+++ b/ObservatoryCore/PluginManagement/PluginEventHandler.cs
@@ -151,7 +151,9 @@ namespace Observatory.PluginManagement
 
         public void OnPluginMessageEvent(object? _, PluginMessageArgs messageArgs)
         {
-            foreach (var plugin in observatoryNotifiers.Cast<IObservatoryPlugin>().Concat(observatoryWorkers))
+            foreach (var plugin in observatoryNotifiers.Cast<IObservatoryPlugin>().Union(observatoryWorkers)
+                .Where(x => String.IsNullOrEmpty(messageArgs.TargetShortName) || x.ShortName == messageArgs.TargetShortName)
+                .Where(x => x.Name != messageArgs.SourceName))
             {
                 if (disabledPlugins.Contains(plugin)) continue;
 
@@ -217,12 +219,14 @@ namespace Observatory.PluginManagement
     {
         internal string SourceName;
         internal string SourceVersion;
+        internal string TargetShortName;
         internal object Message;
 
-        internal PluginMessageArgs(string sourceName, string sourceVersion, object message)
+        internal PluginMessageArgs(string sourceName, string sourceVersion, string targetShortName, object message)
         {
             SourceName = sourceName;
             SourceVersion = sourceVersion;
+            TargetShortName = targetShortName;
             Message = message;
         }
     }

--- a/ObservatoryFramework/Interfaces.cs
+++ b/ObservatoryFramework/Interfaces.cs
@@ -328,6 +328,12 @@ namespace Observatory.Framework.Interfaces
         public void SendPluginMessage(IObservatoryPlugin plugin, object message);
 
         /// <summary>
+        /// Sends arbitrary data to a specific plugin, identified by ShortName. 
+        /// The full name and version of the sending plugin will be used to identify the sender to recipient.
+        /// </summary>
+        public void SendPluginMessage(IObservatoryPlugin plugin, string targetShortName, object message);
+
+        /// <summary>
         /// Register a UI control for themeing.
         /// </summary>
         /// <param name="control">UI Control object or ToolStripMenuItem</param>

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -1790,6 +1790,12 @@
             Sends arbitrary data to all other plugins. The full name and version of the sending plugin will be used to identify the sender to any recipients.
             </summary>
         </member>
+        <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.SendPluginMessage(Observatory.Framework.Interfaces.IObservatoryPlugin,System.String,System.Object)">
+            <summary>
+            Sends arbitrary data to a specific plugin, identified by ShortName. 
+            The full name and version of the sending plugin will be used to identify the sender to recipient.
+            </summary>
+        </member>
         <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.RegisterControl(System.Object)">
             <summary>
             Register a UI control for themeing.


### PR DESCRIPTION
Add ability for plugins to send messages to specific plugins instead of always broadcast. Stop senders receiving their own messages. Stop plugins that are both notifiers and workers receiving messages twice.