### PR TITLE
chore(framework): Improve serialization support in JSON object model

### DIFF
--- a/ObservatoryFramework/Files/Converters/MaterialCompositionConverter.cs
+++ b/ObservatoryFramework/Files/Converters/MaterialCompositionConverter.cs
@@ -48,7 +48,7 @@ namespace Observatory.Framework.Files.Converters
 
         public override void Write(Utf8JsonWriter writer, ImmutableList<MaterialComposition> value, JsonSerializerOptions options)
         {
-            throw new NotImplementedException();
+            if (value.Count != 0) JsonSerializer.Serialize(writer, value, options);
         }
     }
 }

--- a/ObservatoryFramework/Files/Converters/StarPosConverter.cs
+++ b/ObservatoryFramework/Files/Converters/StarPosConverter.cs
@@ -18,7 +18,8 @@ namespace Observatory.Framework.Files.Converters
 
         public override void Write(Utf8JsonWriter writer, StarPosition value, JsonSerializerOptions options)
         {
-            throw new NotImplementedException();
+            double[] values = { value.x, value.y, value.z };
+            JsonSerializer.Serialize(writer, values, options);
         }
     }
 }

--- a/ObservatoryFramework/Files/Journal/Exploration/Scan.cs
+++ b/ObservatoryFramework/Files/Journal/Exploration/Scan.cs
@@ -27,19 +27,22 @@ namespace Observatory.Framework.Files.Journal
             {
                 _Parents = value;
                 var ParentList = new System.Collections.Generic.List<(ParentType ParentType, int Body)>();
-                foreach (var parent in value)
+                if (value != null)
                 {
-                    if (parent.Null != null)
+                    foreach (var parent in value)
                     {
-                        ParentList.Add((ParentType.Null, parent.Null.GetValueOrDefault(0)));
-                    }
-                    else if (parent.Planet != null)
-                    {
-                        ParentList.Add((ParentType.Planet, parent.Planet.GetValueOrDefault(0)));
-                    }
-                    else if (parent.Star != null)
-                    {
-                        ParentList.Add((ParentType.Star, parent.Star.GetValueOrDefault(0)));
+                        if (parent.Null != null)
+                        {
+                            ParentList.Add((ParentType.Null, parent.Null.GetValueOrDefault(0)));
+                        }
+                        else if (parent.Planet != null)
+                        {
+                            ParentList.Add((ParentType.Planet, parent.Planet.GetValueOrDefault(0)));
+                        }
+                        else if (parent.Star != null)
+                        {
+                            ParentList.Add((ParentType.Star, parent.Star.GetValueOrDefault(0)));
+                        }
                     }
                 }
                 Parent = ParentList.ToImmutableList();
@@ -78,6 +81,7 @@ namespace Observatory.Framework.Files.Journal
         /// <summary>
         /// List containing full breakdown of atmospheric components and their relative percentages.
         /// </summary>
+        [JsonConverter(typeof(MaterialCompositionConverter))]
         public ImmutableList<MaterialComposition> AtmosphereComposition { get; init; }
         /// <summary>
         /// Descriptive string for type of volcanism present, or an empty string for none, e.g. "major silicate vapour geysers volcanism".

--- a/ObservatoryFramework/Files/Journal/JournalBase.cs
+++ b/ObservatoryFramework/Files/Journal/JournalBase.cs
@@ -7,6 +7,7 @@ namespace Observatory.Framework.Files.Journal
     public class JournalBase
     {
         [JsonPropertyName("timestamp")]
+        [JsonPropertyOrder(-2)]
         public string Timestamp { get; init; }
 
         [JsonIgnore]
@@ -16,6 +17,7 @@ namespace Observatory.Framework.Files.Journal
         }
 
         [JsonPropertyName("event")]
+        [JsonPropertyOrder(-1)]
         public string Event { get;  init; }
 
         [JsonExtensionData]

--- a/ObservatoryFramework/Files/Journal/Travel/Location.cs
+++ b/ObservatoryFramework/Files/Journal/Travel/Location.cs
@@ -17,7 +17,7 @@ namespace Observatory.Framework.Files.Journal
         {
             get
             {
-                return SystemFaction.FactionState;
+                return SystemFaction?.FactionState ?? string.Empty;
             }
             init
             {


### PR DESCRIPTION
I'm working on something that creates Journal objects and serializes them back to JSON... There are a few shortcomings of the current serialization situation, this is some improvement:

* Add some Converter write-path implementations
* Add a few bits of null handling
* Add JSON property ordering attribute to JournalBase so timestamp and event are emitted first when serializing (I did not go so far as to set this on every class; it's not THAT important). NOTE that the default value is 0, so these are negative. The default is actually quite annoying.
* Apply the MaterialCompositionConverter to Scan.AtmosphereComposition

Nothing here should be breaking. All the other plugins I use compiled and/or ran fine with this change.