### PR TITLE
fix(core): Improve settings handling, hygiene, and error handling

### DIFF
--- a/ObservatoryCore/UI/PluginList.cs
+++ b/ObservatoryCore/UI/PluginList.cs
@@ -246,6 +246,9 @@ namespace Observatory.UI
                 case PluginManager.PluginStatus.Errored:
                     return "Error";
 
+                case PluginManager.PluginStatus.SettingsReset:
+                    return "Settings error; using defaults";
+
                 default:
                     return string.Empty;
             }


### PR DESCRIPTION
Three main changes:
* Plugin settings (the whole value) is no longer parsed for every unique plugin that is loaded.
* Settings load failures will result in plugin settings being reset, and not prevent the whole plugin from loading, nor cause ObsCore crashes. Such cases are now explicitly called out in the plugin list.
* Settings for old plugins are now purged (but only if all plugins successfully load, to avoid oopsies wiping your hard work out). This will reduce the size of plugins settings by a fair amount if you've not cleaned them out recently (due to plugin renames and attrition).
* Serializer options are now consistently used and no longer track references (cycles are just ignored now). Because of prior inconsistencies, existing plugins will fail due to conflicting references if fully embraced.

Testing with old settings appears to be without errors, so no compatibility issues that I can find. Cruft added by the former method of ReferenceHandling will be ignored and cleaned out over time as settings are edited.

![image](https://github.com/user-attachments/assets/7ca004e2-a290-4e58-af13-a4fc78d69a27)
