### PR TITLE
fix(Core,Botanist): Persistent Notification fixes

### DIFF
--- a/ObservatoryBotanist/Botanist.cs
+++ b/ObservatoryBotanist/Botanist.cs
@@ -71,7 +71,6 @@ namespace Observatory.Botanist
 
         ObservableCollection<object> GridCollection;
         private PluginUI pluginUI;
-        private Guid? samplerStatusNotification = null;
         private NotificationArgs currentNotificationArgs = null;
         private (double lat, double lon) firstScanLocation = INVALID_LOCATION;
         private (double lat, double lon) secondScanLocation = INVALID_LOCATION;
@@ -166,70 +165,76 @@ namespace Observatory.Botanist
                         else
                         {
                             var bioPlanet = BioPlanets[systemBodyId];
-                            
+
                             // If this is null don't bother.
                             if (scanOrganic.Species_Localised != null)
-                            switch (scanOrganic.ScanType)
                             {
-                                case ScanOrganicType.Log:
-                                case ScanOrganicType.Sample:
-                                    if (!Core.IsLogMonitorBatchReading && botanistSettings.OverlayEnabled)
-                                    {
-                                        var colonyDistance = GetColonyDistance(scanOrganic);
-                                        var sampleNum = scanOrganic.ScanType == ScanOrganicType.Log ? 1 : 2;
-                                        var status = Core.GetStatus() ?? new() 
-                                        { 
-                                            Latitude = 200, 
-                                            Longitude = 200,
-                                            PlanetRadius = 0
-                                        }; // INVALID_LOCATION
-                                        
-                                        if (sampleNum == 1)
+                                switch (scanOrganic.ScanType)
+                                {
+                                    case ScanOrganicType.Log:
+                                    case ScanOrganicType.Sample:
+                                        if (!Core.IsLogMonitorBatchReading && botanistSettings.OverlayEnabled)
                                         {
-                                            firstScanLocation = (status.Latitude, status.Longitude);
-                                            secondScanLocation = INVALID_LOCATION;
-                                        }
-                                        else if (sampleNum == 2)
-                                            secondScanLocation = (status.Latitude, status.Longitude);
-                                        
-                                        currentBodyRadius = status.PlanetRadius;
-                                        currentNotificationArgs = new()
-                                        {
-                                            Title = scanOrganic.Species_Localised,
-                                            Detail = $"Sample {sampleNum} of 3{Environment.NewLine}Colony distance: {colonyDistance}m{Environment.NewLine}{GetDistanceText(status)}",
-                                            Rendering = NotificationRendering.NativeVisual,
-                                            Timeout = botanistSettings.OverlayIsSticky ? 0 : -1,
-                                            Sender = AboutInfo.ShortName,
-                                        };
-                                        if (samplerStatusNotification == null)
-                                        {
-                                            var notificationId = Core.SendNotification(currentNotificationArgs);
-                                            if (botanistSettings.OverlayIsSticky)
-                                                samplerStatusNotification = notificationId;
-                                        }
-                                        else
-                                        {
-                                            Core.UpdateNotification(samplerStatusNotification.Value, currentNotificationArgs);
-                                        }
-                                    }
+                                            var colonyDistance = GetColonyDistance(scanOrganic);
+                                            var sampleNum = scanOrganic.ScanType == ScanOrganicType.Log ? 1 : 2;
+                                            var status = Core.GetStatus() ?? new()
+                                            {
+                                                Latitude = 200,
+                                                Longitude = 200,
+                                                PlanetRadius = 0
+                                            }; // INVALID_LOCATION
 
-                                    if (!bioPlanet.SpeciesFound.ContainsKey(scanOrganic.Species_Localised))
-                                    {
-                                        bioPlanet.SpeciesFound.Add(scanOrganic.Species_Localised, new()
+                                            if (sampleNum == 1)
+                                            {
+                                                firstScanLocation = (status.Latitude, status.Longitude);
+                                                secondScanLocation = INVALID_LOCATION;
+                                            }
+                                            else if (sampleNum == 2)
+                                                secondScanLocation = (status.Latitude, status.Longitude);
+
+                                            currentBodyRadius = status.PlanetRadius;
+                                            if (scanOrganic.ScanType == ScanOrganicType.Log)
+                                            {
+                                                MaybeCloseSamplerStatusNotification(); // Force a new notification.
+                                            }
+                                            var notificationGuid = currentNotificationArgs?.Guid ?? Guid.NewGuid();
+                                            currentNotificationArgs = new()
+                                            {
+                                                Title = scanOrganic.Species_Localised,
+                                                Detail = $"Sample {sampleNum} of 3{Environment.NewLine}Colony distance: {colonyDistance}m{Environment.NewLine}{GetDistanceText(status)}",
+                                                Rendering = NotificationRendering.NativeVisual,
+                                                Timeout = botanistSettings.OverlayIsSticky ? 0 : -1,
+                                                Sender = AboutInfo.ShortName,
+                                                Guid = notificationGuid,
+                                            };
+                                            if (!botanistSettings.OverlayIsSticky || scanOrganic.ScanType == ScanOrganicType.Log)
+                                            {
+                                                Core.SendNotification(currentNotificationArgs);
+                                            }
+                                            else
+                                            {
+                                                Core.UpdateNotification(notificationGuid, currentNotificationArgs);
+                                            }
+                                        }
+
+                                        if (!bioPlanet.SpeciesFound.ContainsKey(scanOrganic.Species_Localised))
                                         {
-                                            Genus = EnglishGenusByIdentifier.GetValueOrDefault(scanOrganic.Genus, scanOrganic.Genus_Localised),
-                                            Analysed = false
-                                        });
-                                    }
-                                    break;
-                                case ScanOrganicType.Analyse:
-                                    if (!bioPlanet.SpeciesFound[scanOrganic.Species_Localised].Analysed)
-                                    {
-                                        bioPlanet.SpeciesFound[scanOrganic.Species_Localised].Analysed = true;
-                                    }
-                                    MaybeCloseSamplerStatusNotification();
-                                    firstScanLocation = INVALID_LOCATION; secondScanLocation = INVALID_LOCATION;
-                                    break;
+                                            bioPlanet.SpeciesFound.Add(scanOrganic.Species_Localised, new()
+                                            {
+                                                Genus = EnglishGenusByIdentifier.GetValueOrDefault(scanOrganic.Genus, scanOrganic.Genus_Localised),
+                                                Analysed = false
+                                            });
+                                        }
+                                        break;
+                                    case ScanOrganicType.Analyse:
+                                        if (!bioPlanet.SpeciesFound[scanOrganic.Species_Localised].Analysed)
+                                        {
+                                            bioPlanet.SpeciesFound[scanOrganic.Species_Localised].Analysed = true;
+                                        }
+                                        MaybeCloseSamplerStatusNotification();
+                                        firstScanLocation = INVALID_LOCATION; secondScanLocation = INVALID_LOCATION;
+                                        break;
+                                }
                             }
                         }
                         UpdateUIGrid();
@@ -248,14 +253,14 @@ namespace Observatory.Botanist
 
         public void StatusChange(Status status)
         {
-            if (samplerStatusNotification != null)
+            if (currentNotificationArgs != null)
             {
                 var currentNotificationDetail = currentNotificationArgs.Detail.Split(Environment.NewLine);
 
                 currentNotificationDetail[2] = GetDistanceText(status);
                 
                 currentNotificationArgs.Detail = string.Join(Environment.NewLine, currentNotificationDetail);
-                Core.UpdateNotification(samplerStatusNotification.Value, currentNotificationArgs);
+                Core.UpdateNotification(currentNotificationArgs.Guid.Value, currentNotificationArgs);
             }
         }
 
@@ -295,10 +300,10 @@ namespace Observatory.Botanist
 
         private void MaybeCloseSamplerStatusNotification()
         {
-            if (samplerStatusNotification != null)
+            if (currentNotificationArgs != null)
             {
-                Core.CancelNotification(samplerStatusNotification.Value);
-                samplerStatusNotification = null;
+                Core.CancelNotification(currentNotificationArgs.Guid.Value);
+                currentNotificationArgs = null;
             }
         }
 

--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -91,24 +91,25 @@ namespace Observatory.PluginManagement
 
         public void UpdateNotification(Guid id, NotificationArgs notificationArgs)
         {
-            if (!IsLogMonitorBatchReading)
+            if (IsLogMonitorBatchReading) return;
+
+            if (!notificationArgs.Guid.HasValue) notificationArgs.Guid = id;
+
+            if ((notificationArgs.Rendering & NotificationRendering.PluginNotifier) != 0)
             {
-                if ((notificationArgs.Rendering & NotificationRendering.PluginNotifier) != 0)
-                {
-                    var handler = Notification;
-                    handler?.Invoke(this, notificationArgs);
-                }
-
-                if ((notificationArgs.Rendering & NotificationRendering.NativeVisual) != 0)
-                    NativePopup.UpdateNotification(id, notificationArgs);
-
-                if (Properties.Core.Default.VoiceNotify && (notificationArgs.Rendering & NotificationRendering.NativeVocal) != 0)
-                {
-                    NativeVoice.AudioHandlerEnqueue(notificationArgs);
-                }
-
-                UpdateNotificationEvent?.Invoke(this, notificationArgs);
+                var handler = Notification;
+                handler?.Invoke(this, notificationArgs);
             }
+
+            if ((notificationArgs.Rendering & NotificationRendering.NativeVisual) != 0)
+                NativePopup.UpdateNotification(id, notificationArgs);
+
+            if (Properties.Core.Default.VoiceNotify && (notificationArgs.Rendering & NotificationRendering.NativeVocal) != 0)
+            {
+                NativeVoice.AudioHandlerEnqueue(notificationArgs);
+            }
+
+            UpdateNotificationEvent?.Invoke(this, notificationArgs);
         }
 
         /// <summary>


### PR DESCRIPTION
Botanist: ensure notification GUID is set on the notificationArgs. Remove redundant Guid member variable.

Core: Set the provided Guid on provided notification args if not already set when updating a notification.

Tested with latest StellarOverlay beta.