### PR TITLE
feat(framework,core): Add support for PP2.0 objects, StationService enum

### DIFF
--- a/ObservatoryCore/Utils/LogMonitor.cs
+++ b/ObservatoryCore/Utils/LogMonitor.cs
@@ -149,7 +149,9 @@ namespace Observatory.Utils
                         fileHeaderLines.Clear();
                         fileHeaderLines.Add(line);
                     }
-                    else if (eventType.Equals("LoadGame") || eventType.Equals("Statistics"))
+                    else if (eventType.Equals("LoadGame") ||
+                        eventType.Equals("Statistics") ||
+                        eventType.Equals("CarrierLocation"))
                     {
                         // A few header lines to collect.
                         fileHeaderLines.Add(line);

--- a/ObservatoryFramework/Files/Converters/StationServiceConverter.cs
+++ b/ObservatoryFramework/Files/Converters/StationServiceConverter.cs
@@ -4,6 +4,7 @@ using Observatory.Framework.Files.ParameterTypes;
 
 namespace Observatory.Framework.Files.Converters
 {
+    [Obsolete("Replaced by JsonStringEnumMemberConverter which can handle unkonwn values.")]
     public class StationServiceConverter : JsonConverter<StationService>
     {
         public override StationService Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/ObservatoryFramework/Files/Journal/FleetCarrier/CarrierJump.cs
+++ b/ObservatoryFramework/Files/Journal/FleetCarrier/CarrierJump.cs
@@ -18,11 +18,9 @@ namespace Observatory.Framework.Files.Journal
         public Faction StationFaction { get; init; }
         public string StationGovernment { get; init; }
         public string StationGovernment_Localised { get; init; }
-        [JsonConverter(typeof(StationServiceConverter))]
         public StationService StationServices { get; init; }
         public string StationEconomy { get; init; }
         public string StationEconomy_Localised { get; init; }
         public ImmutableList<StationEconomy> StationEconomies { get; init; }
-        public string Power { get; init; }
     }
 }

--- a/ObservatoryFramework/Files/Journal/FleetCarrier/CarrierLocation.cs
+++ b/ObservatoryFramework/Files/Journal/FleetCarrier/CarrierLocation.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.Framework.Files.Journal
+{
+    public class CarrierLocation : JournalBase
+    {
+        public ulong CarrierID { get; init; }
+        public string StarSystem { get; init; }
+        public ulong SystemAddress { get; init; }
+        public int BodyID { get; init; }
+    }
+}

--- a/ObservatoryFramework/Files/Journal/Other/ApproachSettlement.cs
+++ b/ObservatoryFramework/Files/Journal/Other/ApproachSettlement.cs
@@ -21,7 +21,6 @@ namespace Observatory.Framework.Files.Journal
         public Faction StationFaction { get; init; }
         public string StationGovernment { get; init; }
         public string StationGovernment_Localised { get; init; }
-        [JsonConverter(typeof(StationServiceConverter))]
         public StationService StationServices { get; init; }
     }
 }

--- a/ObservatoryFramework/Files/Journal/Powerplay/PowerplayMerits.cs
+++ b/ObservatoryFramework/Files/Journal/Powerplay/PowerplayMerits.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.Framework.Files.Journal
+{
+    public class PowerplayMerits : JournalBase
+    {
+        public string Power { get; init; }
+        public int MeritsGained { get; init; }
+        public int TotalMerits { get; init; }
+    }
+}

--- a/ObservatoryFramework/Files/Journal/Powerplay/PowerplayRank.cs
+++ b/ObservatoryFramework/Files/Journal/Powerplay/PowerplayRank.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.Framework.Files.Journal
+{
+    public class PowerplayRank : JournalBase
+    {
+        public string Power { get; init; }
+        public int Rank { get; init; }
+    }
+}

--- a/ObservatoryFramework/Files/Journal/StationServices/Market.cs
+++ b/ObservatoryFramework/Files/Journal/StationServices/Market.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 using Observatory.Framework.Files.ParameterTypes;
 
 namespace Observatory.Framework.Files.Journal
@@ -11,6 +12,7 @@ namespace Observatory.Framework.Files.Journal
         /// Name of the station at which this event occurred.
         /// </summary>
         public string StationName { get; init; }
+        public string StationName_Localised { get; init; }
         public string StationType { get; init; }
         public string StarSystem { get; init; }
         public CarrierDockingAccess CarrierDockingAccess { get; init; }

--- a/ObservatoryFramework/Files/Journal/Travel/Docked.cs
+++ b/ObservatoryFramework/Files/Journal/Travel/Docked.cs
@@ -11,6 +11,7 @@ namespace Observatory.Framework.Files.Journal
         /// Name of the station at which this event occurred.
         /// </summary>
         public string StationName { get; init; }
+        public string StationName_Localised { get; init; }
         public string StationType { get; init; }
         public string StarSystem { get; init; }
         public ulong SystemAddress { get; init; }

--- a/ObservatoryFramework/Files/Journal/Travel/Docked.cs
+++ b/ObservatoryFramework/Files/Journal/Travel/Docked.cs
@@ -72,7 +72,6 @@ namespace Observatory.Framework.Files.Journal
             init { StationAllegiance = value; }
         }
 
-        [JsonConverter(typeof(Converters.StationServiceConverter))]
         public StationService StationServices { get; init; }
         public string StationEconomy { get; init; }
 

--- a/ObservatoryFramework/Files/Journal/Travel/DockingRequested.cs
+++ b/ObservatoryFramework/Files/Journal/Travel/DockingRequested.cs
@@ -8,6 +8,7 @@ namespace Observatory.Framework.Files.Journal
         /// Name of the station at which this event occurred.
         /// </summary>
         public string StationName { get; init; }
+        public string StationName_Localised { get; init; }
         public string StationType { get; init; }
         public ulong MarketID { get; init; }
         public LandingPads LandingPads { get; init; }

--- a/ObservatoryFramework/Files/Journal/Travel/FSDJump.cs
+++ b/ObservatoryFramework/Files/Journal/Travel/FSDJump.cs
@@ -47,6 +47,10 @@ namespace Observatory.Framework.Files.Journal
         public ImmutableList<Conflict> Conflicts { get; init; }
         public ImmutableList<string> Powers { get; init; }
         public string PowerplayState { get; init; }
+        public double PowerplayStateControlProgress { get; init; }
+        public int PowerplayStateReinforcement { get; init; }
+        public int PowerplayStateUndermining { get; init; }
+        public ImmutableList<PowerplayStateConflictProgress> PowerplayConflictProgress { get; init; }
         public bool Taxi { get; init; }
         public bool Multicrew { get; init; }
         public ThargoidWar ThargoidWar { get; init; }

--- a/ObservatoryFramework/Files/Journal/Travel/Location.cs
+++ b/ObservatoryFramework/Files/Journal/Travel/Location.cs
@@ -28,6 +28,7 @@ namespace Observatory.Framework.Files.Journal
         /// Name of the station at which this event occurred.
         /// </summary>
         public string StationName { get; init; }
+        public string StationName_Localised { get; init; }
         public string StationType { get; init; }
         public float Longitude { get; init; }
         public float Latitude { get; init; }
@@ -67,6 +68,10 @@ namespace Observatory.Framework.Files.Journal
         public ImmutableList<Conflict> Conflicts { get; init; }
         public ImmutableList<string> Powers { get; init; }
         public string PowerplayState { get; init; }
+        public double PowerplayStateControlProgress { get; init; }
+        public int PowerplayStateReinforcement { get; init; }
+        public int PowerplayStateUndermining { get; init; }
+        public ImmutableList<PowerplayStateConflictProgress> PowerplayConflictProgress { get; init; }
         public bool Taxi { get; init; }
         public bool Multicrew { get; init; }
         public bool OnFoot { get; init; }

--- a/ObservatoryFramework/Files/Journal/Travel/Undocked.cs
+++ b/ObservatoryFramework/Files/Journal/Travel/Undocked.cs
@@ -6,6 +6,7 @@
         /// Name of the station at which this event occurred.
         /// </summary>
         public string StationName { get; init; }
+        public string StationName_Localised { get; init; }
         public string StationType { get; init; }
         public ulong MarketID { get; init; }
         public bool Taxi { get; init; }

--- a/ObservatoryFramework/Files/MarketFile.cs
+++ b/ObservatoryFramework/Files/MarketFile.cs
@@ -17,6 +17,10 @@ namespace Observatory.Framework.Files
         /// </summary>
         public string StationName { get; init; }
         /// <summary>
+        /// Name of the station where the market is located localised to the current language (if available).
+        /// </summary>
+        public string StationName_Localised { get; init; }
+        /// <summary>
         /// Type of station where the market is located.
         /// </summary>
         public string StationType { get; init; }

--- a/ObservatoryFramework/Files/ParameterTypes/Enumerations.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/Enumerations.cs
@@ -377,6 +377,8 @@ namespace Observatory.Framework.Files.ParameterTypes
         UnrecognisedValue
     }
 
+    [JsonStringEnumMemberConverterOptions(deserializationFailureFallbackValue: None)]
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     [System.Flags]
     public enum StationService : ulong
     {
@@ -424,6 +426,7 @@ namespace Observatory.Framework.Files.ParameterTypes
         ApexInterstellar = 1L << 39,
         FrontlineSolutions = 1L << 40,
         RegisteringColonisation = 1L << 41,
+        ColonisationContribution = 1L << 42,
     }
 
     [JsonStringEnumMemberConverterOptions(deserializationFailureFallbackValue: UnrecognisedValue)]

--- a/ObservatoryFramework/Files/ParameterTypes/Enumerations.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/Enumerations.cs
@@ -420,9 +420,10 @@ namespace Observatory.Framework.Files.ParameterTypes
         SocialSpace = 1L << 35,
         Bartender = 1L << 36,
         VistaGenomics = 1L << 37,
-        PioneerSupplies = 1L << 38,
+        PioneerSupplies = 1L << 38, 
         ApexInterstellar = 1L << 39,
-        FrontlineSolutions = 1L << 40
+        FrontlineSolutions = 1L << 40,
+        RegisteringColonisation = 1L << 41,
     }
 
     [JsonStringEnumMemberConverterOptions(deserializationFailureFallbackValue: UnrecognisedValue)]

--- a/ObservatoryFramework/Files/ParameterTypes/Mission.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/Mission.cs
@@ -6,6 +6,8 @@
 
         public string Name { get; init; }
 
+        public string Name_Localised { get; init; }
+
         public bool PassengerMission { get; init; }
 
         public int Expires { get; init; }

--- a/ObservatoryFramework/Files/ParameterTypes/PowerplayStateConflictProgress.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/PowerplayStateConflictProgress.cs
@@ -1,0 +1,15 @@
+﻿using Observatory.Framework.Files.Journal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.Framework.Files.ParameterTypes
+{
+    public class PowerplayStateConflictProgress : JournalBase
+    {
+        public string Power { get; init; }
+        public double ConflictProgress { get; init; }
+    }
+}

--- a/ObservatoryFramework/Files/ParameterTypes/WarFaction.cs
+++ b/ObservatoryFramework/Files/ParameterTypes/WarFaction.cs
@@ -5,6 +5,7 @@
         public string Name { get; init; }
 
         public string Stake { get; init; }
+        public string Stake_Localised { get; init; }
 
         public int WonDays { get; init; }
     }

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -1256,6 +1256,11 @@
             Name of the station where the market is located.
             </summary>
         </member>
+        <member name="P:Observatory.Framework.Files.MarketFile.StationName_Localised">
+            <summary>
+            Name of the station where the market is located localised to the current language (if available).
+            </summary>
+        </member>
         <member name="P:Observatory.Framework.Files.MarketFile.StationType">
             <summary>
             Type of station where the market is located.


### PR DESCRIPTION
Looked at recent changes to the jixxed/ed-journal-schemas and patching in PP2.0 and a colonisation change for a missing enum values (for StationService) which can cause some journals to fail to deserialize -- not covered in b944dc1. `StationServiceConverter` is now deprecated in favor of the generic one added in https://github.com/Xjph/ObservatoryCore/commit/b944dc161bdbaf8eee7e32b3e7944b760553bf0d (which appears to work with flag-based enums too). I suspect more colonisation journals will come once the feature is out of beta.

There are a few new localized strings (ie. StationName_Localised -- which would be useful to check if populated).

Of note is the new CarrierLocation event (emitted at game startup) which is now collected and replayed by LogMonitor.

NOTE: I removed the redundant `Power` property from CarrierJump -- it's defined in FSDJump (base class) and was unintentionally hiding it. AFAIK, this should not break compatibility. Can revert if it does.