### PR TITLE
feat(Core): Add a context menu for the core tab

### DIFF
--- a/ObservatoryCore/UI/CoreContextMenu.cs
+++ b/ObservatoryCore/UI/CoreContextMenu.cs
@@ -1,0 +1,54 @@
+﻿using NAudio.Gui;
+using Observatory.Framework;
+using Observatory.Framework.Interfaces;
+using Observatory.PluginManagement;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.Intrinsics.X86;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.UI
+{
+    internal class CoreContextMenu : ContextMenuStrip
+    {
+        internal CoreContextMenu(AboutInfo coreAboutInfo, Action coreSettingsDelegate, Action pluginsFolderDelegate)
+        {
+            ToolStripMenuItem settings = new()
+            {
+                Text = "Core Settings"
+            };
+            ToolStripMenuItem about = new()
+            {
+                Text = $"About Core"
+            };
+            ToolStripMenuItem pluginsFolder = new()
+            {
+                Text = $"Open Plugins Folder"
+            };
+
+            Items.Add(settings);
+            Items.Add(about);
+            Items.Add(pluginsFolder);
+
+            ItemClicked += (o, e) =>
+            {
+                if (e.ClickedItem == settings)
+                {
+                    coreSettingsDelegate();
+                }
+                if (e.ClickedItem == about)
+                {
+                    FormsManager.OpenAboutForm(coreAboutInfo);
+                }
+                if (e.ClickedItem == pluginsFolder)
+                {
+                    pluginsFolderDelegate();
+                }
+            };
+        }
+
+    }
+}

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -480,14 +480,23 @@ namespace Observatory.UI
             {
                 for (int i = 0; i < pluginList.Count; i++)
                 {
-                    if (CoreTabControl.GetTabRect(i + 1).Contains(e.Location))
+                    if (CoreTabControl.GetTabRect(i).Contains(e.Location))
                     {
-                        var pluginPanel = CoreTabControl.TabPages[i + 1];
-                        var clickedPlugin = pluginList[pluginPanel];
+                        var pluginPanel = CoreTabControl.TabPages[i];
+                        // The core tab may not be at index 0 and is not contained in the plugin list.
+                        if (pluginList.ContainsKey(pluginPanel))
+                        {
+                            var clickedPlugin = pluginList[pluginPanel];
 
-                        PluginContextMenu pluginContextMenu = new(clickedPlugin, pluginPanel);
-                        pluginContextMenu.Show((Control)sender, e.Location);
-
+                            PluginContextMenu pluginContextMenu = new(clickedPlugin, pluginPanel);
+                            pluginContextMenu.Show((Control)sender, e.Location);
+                        }
+                        else
+                        {
+                            // Assume the core tab for the moment.
+                            CoreContextMenu coreContextMenu = new(_aboutCore, OpenCoreSettings, OpenPluginsFolder);
+                            coreContextMenu.Show((Control)sender, e.Location);
+                        }
                     }
                 }
             }
@@ -496,7 +505,7 @@ namespace Observatory.UI
 
         private CoreSettings? _coreSettings;
 
-        private void SettingsButton_Click(object sender, EventArgs e)
+        public void OpenCoreSettings()
         {
             if (_coreSettings == null || _coreSettings.IsDisposed)
             {
@@ -508,7 +517,7 @@ namespace Observatory.UI
             _coreSettings.Activate();
         }
 
-        private void PluginFolderButton_Click(object sender, EventArgs e)
+        public void OpenPluginsFolder()
         {
             var pluginDir = Application.StartupPath + "plugins";
 
@@ -519,6 +528,16 @@ namespace Observatory.UI
 
             var fileExplorerInfo = new ProcessStartInfo() { FileName = pluginDir, UseShellExecute = true };
             Process.Start(fileExplorerInfo);
+        }
+
+        private void SettingsButton_Click(object sender, EventArgs e)
+        {
+            OpenCoreSettings();
+        }
+
+        private void PluginFolderButton_Click(object sender, EventArgs e)
+        {
+            OpenPluginsFolder();
         }
     }
 }

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -505,7 +505,7 @@ namespace Observatory.UI
 
         private CoreSettings? _coreSettings;
 
-        public void OpenCoreSettings()
+        internal void OpenCoreSettings()
         {
             if (_coreSettings == null || _coreSettings.IsDisposed)
             {
@@ -517,7 +517,7 @@ namespace Observatory.UI
             _coreSettings.Activate();
         }
 
-        public void OpenPluginsFolder()
+        internal void OpenPluginsFolder()
         {
             var pluginDir = Application.StartupPath + "plugins";
 


### PR DESCRIPTION
And at the same time fix the assumption that Core is the first tab (resulting in the context menu not working for a plugin in that position).

![Screenshot 2025-06-03 141143](https://github.com/user-attachments/assets/54d7f0a5-a25c-4f61-80c7-cf7aa2497515)
