### PR TITLE
fix(core): A few little quick fixes

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -339,7 +339,7 @@ namespace Observatory.PluginManagement
             var workers = EnabledWorkerPlugins;
             var notifiers = EnabledNotifyPlugins;
 
-            foreach (IObservatoryPlugin plugin in workers.Concat<IObservatoryPlugin>(notifiers))
+            foreach (IObservatoryPlugin plugin in workers.Union<IObservatoryPlugin>(notifiers))
             {
                 try
                 {
@@ -349,15 +349,6 @@ namespace Observatory.PluginManagement
                 {
                     core.GetPluginErrorLogger(plugin)(ex, "in ObservatoryReady()");
                 }
-            }
-        }
-
-        private static string ComputeSha512Hash(string filePath)
-        {
-            using (var SHA512 = System.Security.Cryptography.SHA512.Create())
-            {
-                using (FileStream fileStream = File.OpenRead(filePath))
-                    return BitConverter.ToString(SHA512.ComputeHash(fileStream)).Replace("-", "").ToLowerInvariant();
             }
         }
 

--- a/ObservatoryCore/UI/CoreForm.cs
+++ b/ObservatoryCore/UI/CoreForm.cs
@@ -478,7 +478,9 @@ namespace Observatory.UI
         {
             if (e.Button == MouseButtons.Right)
             {
-                for (int i = 0; i < pluginList.Count; i++)
+                // Note there are pluginList.Count + 1 tabs, including Core tab -- which we can handle here.
+                // And since we're not accessing PluginList (a dictionary) by index, this is safe to do.
+                for (int i = 0; i <= pluginList.Count; i++)
                 {
                     if (CoreTabControl.GetTabRect(i).Contains(e.Location))
                     {


### PR DESCRIPTION
1. Following up the fix from #220, also show tab context menus on the LAST tab (whether it's Core or a plugin).
2. Prevent duplicate ObservatoryReady calls to plugins with both notifier and worker implementations.
3. And clean up an unused function.