### PR TITLE
fix(Core): Consider Ancillary files as stale during pre-read.

### DIFF
--- a/ObservatoryCore/Utils/LogMonitor.cs
+++ b/ObservatoryCore/Utils/LogMonitor.cs
@@ -201,7 +201,8 @@ namespace Observatory.Utils
                 JournalEntry?.Invoke(this, journalEvent);
 
                 // Files are only valid if realtime, otherwise they will be stale or empty.
-                if ((currentState & LogMonitorState.Batch) == 0 && EventsWithAncillaryFile.Contains(eventType))
+                if (((currentState & LogMonitorState.Batch) == 0 && (currentState & LogMonitorState.PreRead) == 0)
+                    && EventsWithAncillaryFile.Contains(eventType))
                 {
                     HandleAncillaryFile(eventType);
                 }


### PR DESCRIPTION
When pre-reading -- especially after mining where Cargo is written a lot, this gets **very slow** but turns out the files are equally stale during pre-read as they are during batch. So I have excluded pre-read from processing ancillary files also.