### PR TITLE
cleanup(framework): Remove duplicate SquadronID from SquadronStartup

### DIFF
--- a/ObservatoryFramework/Files/Journal/Squadron/SquadronStartup.cs
+++ b/ObservatoryFramework/Files/Journal/Squadron/SquadronStartup.cs
@@ -5,6 +5,5 @@
         public int CurrentRank { get; init; }
         public string CurrentRankName { get; init; }
         public string CurrentRankName_Localised { get; init; }
-        public ulong SquadronID { get; init; }
     }
 }

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -1023,6 +1023,11 @@
             Whether the body has been previously mapped by a player.
             </summary>
         </member>
+        <member name="P:Observatory.Framework.Files.Journal.Scan.WasFootfalled">
+            <summary>
+            Whether the body has been previously walked on by a player.
+            </summary>
+        </member>
         <member name="T:Observatory.Framework.Files.Journal.ScanBaryCentre">
             <summary>
             Barycentre orbital properties, automatically recorded when any member of a multiple-body orbital arrangement is first scanned.


### PR DESCRIPTION
The property hides the base-class property. May have caused me a bit of grief with using it.

And add missing documentation to ObservatoryFramework.xml.