### PR TITLE
feat(core, framework): v2 Plugin update check and update folder

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -233,6 +233,10 @@ namespace Observatory.PluginManagement
             }
         }
 
+        public string UpdatedPluginsFolder {
+            get => PluginManager.PluginPath; 
+        }
+
         private void MigratePluginStorage(string oldKey, string newKey)
         {
             var oldPath = GetStorageFolderForPlugin(oldKey, false);

--- a/ObservatoryCore/PluginManagement/PluginManager.cs
+++ b/ObservatoryCore/PluginManagement/PluginManager.cs
@@ -23,6 +23,8 @@ namespace Observatory.PluginManagement
             }
         }
 
+        public static string PluginPath = $"{AppDomain.CurrentDomain.BaseDirectory}{Path.DirectorySeparatorChar}plugins";
+
         private static readonly Lazy<PluginManager> _instance = new Lazy<PluginManager>(NewPluginManager);
 
         private static PluginManager NewPluginManager()
@@ -345,7 +347,7 @@ namespace Observatory.PluginManagement
             observatoryNotifiers = [];
             var errorList = new List<(string, string?)>();
 
-            string pluginPath = $"{AppDomain.CurrentDomain.BaseDirectory}{Path.DirectorySeparatorChar}plugins";
+            var pluginPath = PluginPath;
 
             if (Directory.Exists(pluginPath))
             {

--- a/ObservatoryFramework/Interfaces.cs
+++ b/ObservatoryFramework/Interfaces.cs
@@ -117,13 +117,28 @@ namespace Observatory.Framework.Interfaces
 
         /// <summary>
         /// Check if an update is available for the plugin and provide a URL for the update if available.
+        /// 
+        /// Do not implement both this method and <see cref="CheckForPluginUpdate()"/>.
         /// </summary>
         /// <param name="url">Filled with a URL for the update, either direct download or a download site.</param>
         /// <returns>Whether an update is available.</returns>
+        [Obsolete("Deprecated in favour of CheckForPluginUpdate")]
         public bool UpdateAvailable(out string url)
         {
             url = null;
             return false;
+        }
+
+        /// <summary>
+        /// Check if an update is available for the plugin (which may trigger downloading said update) and 
+        /// provides status information along with an optional URL and text to link to the URL.
+        /// 
+        /// Do not implement both this method and <see cref="UpdateAvailable(out string)"/>.
+        /// </summary>
+        /// <returns>A <see cref="PluginUpdateStatus"/> instance describing the status of the plugin update.</returns>
+        public PluginUpdateInfo CheckForPluginUpdate()
+        {
+            return new();
         }
     }
 
@@ -347,6 +362,12 @@ namespace Observatory.Framework.Interfaces
         /// Retrieves and ensures creation of a location which can be used by the plugin to store persistent data.
         /// </summary>
         public string PluginStorageFolder { get; }
+
+        /// <summary>
+        /// Provides a folder for placing plugin packages for updating plugins on restart.
+        /// This path is not guaranteed to be the Core '/plugins' subfolder, so make no assumptions about this location.
+        /// </summary>
+        public string UpdatedPluginsFolder { get; }
 
         /// <summary>
         /// Plays audio file using default audio device.

--- a/ObservatoryFramework/ObservatoryFramework.xml
+++ b/ObservatoryFramework/ObservatoryFramework.xml
@@ -1626,9 +1626,20 @@
         <member name="M:Observatory.Framework.Interfaces.IObservatoryPlugin.UpdateAvailable(System.String@)">
             <summary>
             Check if an update is available for the plugin and provide a URL for the update if available.
+            
+            Do not implement both this method and <see cref="M:Observatory.Framework.Interfaces.IObservatoryPlugin.CheckForPluginUpdate"/>.
             </summary>
             <param name="url">Filled with a URL for the update, either direct download or a download site.</param>
             <returns>Whether an update is available.</returns>
+        </member>
+        <member name="M:Observatory.Framework.Interfaces.IObservatoryPlugin.CheckForPluginUpdate">
+            <summary>
+            Check if an update is available for the plugin (which may trigger downloading said update) and 
+            provides status information along with an optional URL and text to link to the URL.
+            
+            Do not implement both this method and <see cref="M:Observatory.Framework.Interfaces.IObservatoryPlugin.UpdateAvailable(System.String@)"/>.
+            </summary>
+            <returns>A <see cref="T:Observatory.Framework.PluginUpdateStatus"/> instance describing the status of the plugin update.</returns>
         </member>
         <member name="T:Observatory.Framework.Interfaces.IObservatoryWorker">
             <summary>
@@ -1834,6 +1845,12 @@
         <member name="P:Observatory.Framework.Interfaces.IObservatoryCore.PluginStorageFolder">
             <summary>
             Retrieves and ensures creation of a location which can be used by the plugin to store persistent data.
+            </summary>
+        </member>
+        <member name="P:Observatory.Framework.Interfaces.IObservatoryCore.UpdatedPluginsFolder">
+            <summary>
+            Provides a folder for placing plugin packages for updating plugins on restart.
+            This path is not guaranteed to be the Core '/plugins' subfolder, so make no assumptions about this location.
             </summary>
         </member>
         <member name="M:Observatory.Framework.Interfaces.IObservatoryCore.PlayAudioFile(System.String,Observatory.Framework.ParameterTypes.AudioOptions)">
@@ -2083,6 +2100,61 @@
             <summary>
             UI used by Observatory Core settings tab.<br/>
             Not intended for use by plugins.
+            </summary>
+        </member>
+        <member name="T:Observatory.Framework.PluginUpdateStatus">
+            <summary>
+            The update status of a plugin returned via <see cref="T:Observatory.Framework.PluginUpdateInfo"/> from the
+            <see cref="M:Observatory.Framework.Interfaces.IObservatoryPlugin.CheckForPluginUpdate"/> method.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.PluginUpdateStatus.NoUpdate">
+            <summary>
+            Indicates that there is no update available known or available for the plugin. Other properties
+            of the <see cref="T:Observatory.Framework.PluginUpdateInfo"/> class are ignored.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.PluginUpdateStatus.UpdateAvailable">
+            <summary>
+            Indicates that there is an update available for the plugin. It is recommended that plugins provide a download Url
+            via the <see cref="P:Observatory.Framework.PluginUpdateInfo.Url"/> property.
+            </summary>
+        </member>
+        <member name="F:Observatory.Framework.PluginUpdateStatus.UpdateReady">
+            <summary>
+            Indicates that there is an update available and it has already been downloaded and is ready for installation.
+            The user just needs to restart the application to begin using the new version.
+            </summary>
+        </member>
+        <member name="T:Observatory.Framework.PluginUpdateInfo">
+            <summary>
+            A response object that contains information about the state of a plugin update.
+            </summary>
+        </member>
+        <member name="M:Observatory.Framework.PluginUpdateInfo.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Observatory.Framework.PluginUpdateInfo"/> class.
+            With no further modification, it indicates there is no update available.
+            </summary>
+        </member>
+        <member name="P:Observatory.Framework.PluginUpdateInfo.Status">
+            <summary>
+            Gets or sets an enumeration that specifies the state of the plugin update.
+            See <see cref="T:Observatory.Framework.PluginUpdateStatus"/> enum for possible values.
+            </summary>
+        </member>
+        <member name="P:Observatory.Framework.PluginUpdateInfo.Url">
+            <summary>
+            Gets or sets a URL. This URL will most likely point to the download location of the plugin update.
+            However, this can point to other destinations as well (ie. documentation or release notes).
+            See the <see cref="P:Observatory.Framework.PluginUpdateInfo.UrlText"/> property to customized the text the URL is linked to for non-typical uses.
+            </summary>
+        </member>
+        <member name="P:Observatory.Framework.PluginUpdateInfo.UrlText">
+            <summary>
+            Gets or sets optional custom text that is linked to the URL provided by the <see cref="P:Observatory.Framework.PluginUpdateInfo.Url"/> property. Use this
+            to customize the text linked to the URL provided via the <see cref="P:Observatory.Framework.PluginUpdateInfo.Url"/> property.
+            If an empty/no value is provided, default text is provided based on the value of <see cref="P:Observatory.Framework.PluginUpdateInfo.Status"/> property.
             </summary>
         </member>
         <member name="T:System.Text.Json.Serialization.JsonStringEnumMemberConverter">

--- a/ObservatoryFramework/PluginUpdateInfo.cs
+++ b/ObservatoryFramework/PluginUpdateInfo.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Observatory.Framework
+{
+    /// <summary>
+    /// The update status of a plugin returned via <see cref="PluginUpdateInfo"/> from the
+    /// <see cref="Interfaces.IObservatoryPlugin.CheckForPluginUpdate()"/> method.
+    /// </summary>
+    public enum PluginUpdateStatus
+    {
+        /// <summary>
+        /// Indicates that there is no update available known or available for the plugin. Other properties
+        /// of the <see cref="PluginUpdateInfo"/> class are ignored.
+        /// </summary>
+        NoUpdate,
+        /// <summary>
+        /// Indicates that there is an update available for the plugin. It is recommended that plugins provide a download Url
+        /// via the <see cref="PluginUpdateInfo.Url"/> property.
+        /// </summary>
+        UpdateAvailable,
+        /// <summary>
+        /// Indicates that there is an update available and it has already been downloaded and is ready for installation.
+        /// The user just needs to restart the application to begin using the new version.
+        /// </summary>
+        UpdateReady,
+    }
+
+    /// <summary>
+    /// A response object that contains information about the state of a plugin update.
+    /// </summary>
+    public class PluginUpdateInfo
+    {
+        private string _customUrlText = "";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PluginUpdateInfo"/> class.
+        /// With no further modification, it indicates there is no update available.
+        /// </summary>
+        public PluginUpdateInfo()
+        {
+            Status = PluginUpdateStatus.NoUpdate;
+        }
+
+        /// <summary>
+        /// Gets or sets an enumeration that specifies the state of the plugin update.
+        /// See <see cref="PluginUpdateStatus"/> enum for possible values.
+        /// </summary>
+        public PluginUpdateStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets a URL. This URL will most likely point to the download location of the plugin update.
+        /// However, this can point to other destinations as well (ie. documentation or release notes).
+        /// See the <see cref="UrlText"/> property to customized the text the URL is linked to for non-typical uses.
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets optional custom text that is linked to the URL provided by the <see cref="Url"/> property. Use this
+        /// to customize the text linked to the URL provided via the <see cref="Url"/> property.
+        /// If an empty/no value is provided, default text is provided based on the value of <see cref="Status"/> property.
+        /// </summary>
+        public string UrlText
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_customUrlText))
+                {
+                    switch (Status)
+                    {
+                        case PluginUpdateStatus.UpdateAvailable:
+                            return "Update Available";
+                        case PluginUpdateStatus.UpdateReady:
+                            return "Update Ready; Restart the application";
+                        default:
+                            return "";
+                    }
+                }
+                else return _customUrlText;
+            }
+            set => _customUrlText = value;
+        }
+    }
+}


### PR DESCRIPTION
Implement a "v2" plugin update check which returns a PluginUpdateInfo object that allows for more fine-grained responses and URL customization. Marked the V1 version as deprecated. If the v2 returns no change, the v1 method is also checked.

Additionally, a new property has been added to Core that exposes a folder for writing plugin updates if plugins choose to auto-download their updates.

Example: 
<img width="1175" height="642" alt="image" src="https://github.com/user-attachments/assets/9b408a75-84fc-4ec4-b8d9-fa7cd8ebfb62" />
