### PR TITLE
fix(explorer): Add Landable indicator to the Eccentric Orbit criteria

### DIFF
--- a/ObservatoryExplorer/DefaultCriteria.cs
+++ b/ObservatoryExplorer/DefaultCriteria.cs
@@ -141,7 +141,8 @@ namespace Observatory.Explorer
 
             if (settings.HighEccentricity && scan.Eccentricity > 0.9)
             {
-                results.Add("Highly Eccentric Orbit", $"Eccentricity: {Math.Round(scan.Eccentricity, 4)}");
+                var isLandable = scan.Landable ? "Landable with " : "";
+                results.Add($"{isLandable}Highly Eccentric Orbit", $"Eccentricity: {Math.Round(scan.Eccentricity, 4)}");
             }
 
             if (settings.Nested && !isRing && scan.Parent?.Count > 1 && scan.Parent[0].ParentType == ParentType.Planet && scan.Parent[1].ParentType == ParentType.Planet)


### PR DESCRIPTION
By request of SpaceTrash... Adds a "Landable with" to the notification title (which is spoken, if enabled) when the body with the eccentric orbit is landable.