### PR TITLE
fix(core): Correct the plugin folder context menu item target folder

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -280,6 +280,17 @@ namespace Observatory.PluginManagement
             return $"{rootdataDir}{storageKey}-Data{Path.DirectorySeparatorChar}";
         }
 #endif
+        private string StorageKeyFromPlugin(IObservatoryPlugin plugin)
+        {
+            var pluginGuid = plugin.GetType().GetProperty("Guid")?.GetValue(plugin)?.ToString();
+            var pluginAssemblyName = plugin.GetType().Assembly.GetName().Name;
+            return $"{pluginAssemblyName}-{pluginGuid}";
+        }
+
+        internal string GetStorageFolderForPlugin(IObservatoryPlugin plugin)
+        {
+            return GetStorageFolderForPlugin(StorageKeyFromPlugin(plugin));
+        }
 
         internal string GetStorageFolderForPlugin(string storageKey = "", bool create = true)
         {

--- a/ObservatoryCore/UI/PluginContextMenu.cs
+++ b/ObservatoryCore/UI/PluginContextMenu.cs
@@ -50,10 +50,7 @@ namespace Observatory.UI
                 }
                 if (e.ClickedItem == folder)
                 {
-                    var storageKey = plugin.GetType().GetProperty("Guid")?.GetValue(plugin)?.ToString() 
-                        ?? plugin.GetType().Assembly.GetName().Name 
-                        ?? "";
-                    var storageDir = PluginManager.GetInstance.Core.GetStorageFolderForPlugin(storageKey);
+                    var storageDir = PluginManager.GetInstance.Core.GetStorageFolderForPlugin(plugin);
                     if (!string.IsNullOrWhiteSpace(storageDir) && Directory.Exists(storageDir))
                     {
                         var fileExplorerInfo = new ProcessStartInfo() { FileName = storageDir, UseShellExecute = true };


### PR DESCRIPTION
Recent changes (in commit 233fb21)  changed how "storage keys" are constructed for a plugin, but there was logic for creating such a key outside of PluginCore which didn't get updated and thus it was routing me to an old folder which no longer contained data (it was migrated). Refactored that into PluginCore to centralize it and updated to latest form of the storage key.