### PR TITLE
fix(core): Create plugin data folders by default

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -231,7 +231,7 @@ namespace Observatory.PluginManagement
                 }
                 
 
-                return GetStorageFolderForPlugin(pluginStorageKey, false);
+                return GetStorageFolderForPlugin(pluginStorageKey);
             }
         }
 


### PR DESCRIPTION
Fix a new issue in Observatory Core 1.4.2 (introduced in https://github.com/Xjph/ObservatoryCore/commit/233fb21ae9ea8b5d25147e4a13bbecae19e6358d). The flag to create the directory was set to false (from the previous default of true). As such, installing any new plugin that uses the data folder and does not double check this folder exists before using it would fail with an error similar to the following.

```
Stat Scanner: Could not find a part of the path 'C:\Users\<redacted>\AppData\Roaming\ObservatoryCore\ObservatoryStatScanner-398750b9-ffab-4d28-959b-3fc5648853eb'.
 ```

Affected plugins include:
* Herald
* Several of fredjk-gh's plugins including Stat Scanner, probably Fleet Commander, Helm and Archivist as well.

Known OK plugins include:
* AstroAnalytica
* BoxelStats