### PR TITLE
feat(explorer): add a `notifyForBody` method to Lua environment

### DIFF
--- a/ObservatoryExplorer/CustomCriteriaManager.cs
+++ b/ObservatoryExplorer/CustomCriteriaManager.cs
@@ -18,11 +18,11 @@ namespace Observatory.Explorer
         private Dictionary<String,LuaFunction> CriteriaFunctions;
         private Dictionary<string, string> CriteriaWithErrors = new();
         Action<Exception, String> ErrorLogger;
-        private Action<string, string, string, string> NotificationMethod;
+        private Action<string, string, string, string, int?> NotificationMethod;
         private uint ScanCount;
         private string eventTime = string.Empty;
 
-        public CustomCriteriaManager(Action<Exception, String> errorLogger, Action<string, string, string, string> notificationMethod)
+        public CustomCriteriaManager(Action<Exception, String> errorLogger, Action<string, string, string, string, int?> notificationMethod)
         {
             ErrorLogger = errorLogger;
             CriteriaFunctions = new();
@@ -30,7 +30,10 @@ namespace Observatory.Explorer
             NotificationMethod = notificationMethod;
         }
 
-        public void SendNotification(string title, string detail, string extendedDetail) => NotificationMethod(eventTime, title, detail, extendedDetail);
+        public void SendNotification(string title, string detail, string extendedDetail)
+            => NotificationMethod(eventTime, title, detail, extendedDetail, null);
+        public void SendNotificationForBody(string title, string detail, string extendedDetail, int bodyId)
+            => NotificationMethod(eventTime, title, detail, extendedDetail, bodyId);
 
         public void RefreshCriteria(string criteriaPath)
         {
@@ -156,6 +159,7 @@ namespace Observatory.Explorer
             #region Convenience Functions
 
             LuaState.RegisterFunction("notify", this, typeof(CustomCriteriaManager).GetMethod("SendNotification"));
+            LuaState.RegisterFunction("notifyForBody", this, typeof(CustomCriteriaManager).GetMethod("SendNotificationForBody"));
 
             // Body type related functions and tests
 

--- a/ObservatoryExplorer/Explorer.cs
+++ b/ObservatoryExplorer/Explorer.cs
@@ -383,7 +383,7 @@ namespace Observatory.Explorer
             ObservatoryCore.SendNotification(args);
         }
 
-        private void SendNotification(string title, string detail, string extendedDetail)
+        private void SendNotification(string title, string detail, string extendedDetail, int? coalescingId = null)
         {
             NotificationArgs args = new()
             {
@@ -391,7 +391,7 @@ namespace Observatory.Explorer
                 Detail = detail,
                 Sender = ExplorerWorker.AboutInfo.ShortName,
                 ExtendedDetails = extendedDetail,
-                CoalescingId = -1,
+                CoalescingId = coalescingId ?? -1,
             };
 
             ObservatoryCore.SendNotification(args);
@@ -410,9 +410,9 @@ namespace Observatory.Explorer
             ObservatoryCore.AddGridItem(ExplorerWorker, results);
         }
 
-        private void HandleCustomNotification(string eventTime, string title, string detail, string extendedDetail)
+        private void HandleCustomNotification(string eventTime, string title, string detail, string extendedDetail, int? coalescingId = null)
         {
-            SendNotification(title, detail, extendedDetail);
+            SendNotification(title, detail, extendedDetail, coalescingId);
             AddGridItem(eventTime, title, detail, extendedDetail);
         }
 


### PR DESCRIPTION
This allows notifications to mark notifications as for a specific body like `Complex` and `Simple` criteria responses do by default. The Body ID given to this method is set to the Coalescing ID on the notification args.