### PR TITLE
fix(core): make the grouped parameter useful again

### DIFF
--- a/ObservatoryCore/PluginManagement/PluginCore.cs
+++ b/ObservatoryCore/PluginManagement/PluginCore.cs
@@ -151,7 +151,6 @@ namespace Observatory.PluginManagement
         )
         {
             BeginBulkUpdate(worker);
-            grouped = true;
             if (grouped)
             {
                 var groupId = Guid.NewGuid();


### PR DESCRIPTION
Remove stray `grouped = true;` that is overriding the parameter value for `AddGridItems()`.