### PR TITLE
fix(Explorer): Fix a couple custom criteria issues uncovered in discord

### DIFF
--- a/ObservatoryExplorer/CustomCriteriaManager.cs
+++ b/ObservatoryExplorer/CustomCriteriaManager.cs
@@ -94,7 +94,7 @@ namespace Observatory.Explorer
         {
             string criteriaFilePath = Settings.CustomCriteriaFile;
 
-            if (string.IsNullOrWhiteSpace(CriteriaPath) && !CriteriaPath.Equals(criteriaFilePath))
+            if (string.IsNullOrWhiteSpace(CriteriaPath) || !CriteriaPath.Equals(criteriaFilePath))
             {
                 // Different file detected.
                 CriteriaLastModified = DateTime.MinValue;
@@ -156,7 +156,7 @@ namespace Observatory.Explorer
                             i = i + 1
                             while i <= count do
                                 local ring = ring_list[i - 1]
-                                if (filter_by == nil or string.find(ring.Name, filter_by)) then
+                                if (filter_by == nil or string.find(ring.Name, '^.*'..filter_by..'$')) then
                                     return { name = ring.Name, ringclass = ring.RingClass, massmt = ring.MassMT, innerrad = ring.InnerRad, outerrad = ring.OuterRad }
                                 else
                                     i = i + 1
@@ -177,7 +177,7 @@ namespace Observatory.Explorer
                         local i = 0
                         local count = ring_list.Count
                         while i < count do
-                            if string.find(ring_list[i].Name, filter_by) then
+                            if string.find(ring_list[i].Name, '^.*'..filter_by..'$') then
                                 return true
                             end
                             i = i + 1
@@ -279,7 +279,7 @@ namespace Observatory.Explorer
             LuaState.DoString(
                 @"
                 function isBelt (body_name)
-                    return body_name ~= nil and string.find(body_name, 'Belt')
+                    return body_name ~= nil and string.find(body_name, '^.*Belt$')
                 end"
             );
 
@@ -295,7 +295,7 @@ namespace Observatory.Explorer
             LuaState.DoString(
                 @"
                 function isRing (body_name)
-                    return body_name ~= nil and string.find(body_name, 'Ring')
+                    return body_name ~= nil and string.find(body_name, '^.*Ring$')
                 end"
             );
 


### PR DESCRIPTION
Specifically:

1. When switching custom criteria files, Explorer failed to load criteria from the new file (until restart) because of incorrect boolean operator.
2. Use patterns to match "Ring" and "Belt" at the *end* of the body name in various built-in functions to avoid mis-fires on bodies in systems whose name includes the word 'Ring' or 'Belt' (for example Ring Sector ...).

That was a fun debugging session.

Here are some test custom criteria functions which are quite redundant but exercise the whole suite of functions:

```lua
---@Complex isRing/isBelt test
if scan.Rings then
  for r in rings(scan.Rings) do
    if isRing(r.name) then
      notifyForBody(scan.BodyName, 'Ring detected', r.name, scan.BodyID)
    elseif isBelt(r.name) then
      notifyForBody(scan.BodyName, 'Belt detected', r.name, scan.BodyID)
    end
  end
end
---@End Ring test

---@Complex isRing/isBelt test
if scan.Rings then
  for r in ringsOnly(scan.Rings) do
    notifyForBody(scan.BodyName, 'Ring found', string.format('%s; type %s', r.name, r.ringclass), scan.BodyID)
  end
  for r in beltsOnly(scan.Rings) do
    notifyForBody(scan.BodyName, 'Belt found', string.format('%s; type %s', r.name, r.ringclass), scan.BodyID)
  end
end
---@End Ring test

---@Complex hasRings/hasBelts test
if hasRings(scan.Rings) then
    notifyForBody(scan.BodyName, string.format('%d rings detected', scan.Rings.Count), '', scan.BodyID)
elseif hasBelts(scan.Rings) then
    notifyForBody(scan.BodyName, string.format('%d belts detected', scan.Rings.Count), '', scan.BodyID)
end
---@End Ring test
```

A couple test systems:
* Ring Sector TT-R b4-0
* Ring Sector PD-S b4-0

Example test output for the latter system -- the belts around the primary star are correctly detected as belts despite the presence of 'Ring' in the name and rings being checked first in all test criteria.

<img width="2190" height="1728" alt="image" src="https://github.com/user-attachments/assets/14ba24a9-939b-48d8-9612-d934cfb87691" />
